### PR TITLE
Changed default-auth user to service account name, Edited a create/update check, Changed the name of Installationsecret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
 docker-build: ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	docker build --network host -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}
@@ -220,7 +220,7 @@ host-agent-binaries: ## Builds the binaries for the host-agent
 
 host-agent-binary: $(RELEASE_DIR)
 	docker run \
-		--rm \
+		--rm --network host \
 		-e CGO_ENABLED=0 \
 		-e GOOS=$(GOOS) \
 		-e GOARCH=$(GOARCH) \

--- a/agent/cloudinit/cloudinit.go
+++ b/agent/cloudinit/cloudinit.go
@@ -38,9 +38,9 @@ type Files struct {
 }
 
 // Execute performs the following operations on the bootstrap script
-//  - parse the script to get the cloudinit data
-//  - execute the write_files directive
-//  - execute the run_cmd directive
+//   - parse the script to get the cloudinit data
+//   - execute the write_files directive
+//   - execute the run_cmd directive
 func (se ScriptExecutor) Execute(bootstrapScript string) error {
 	cloudInitData := bootstrapConfig{}
 	if err := yaml.Unmarshal([]byte(bootstrapScript), &cloudInitData); err != nil {

--- a/agent/main.go
+++ b/agent/main.go
@@ -38,7 +38,8 @@ import (
 // labelFlags is a flag that holds a map of label key values.
 // One or more key value pairs can be passed using the same flag
 // The following example sets labelFlags with two items:
-//     -label "key1=value1" -label "key2=value2"
+//
+//	-label "key1=value1" -label "key2=value2"
 type labelFlags map[string]string
 
 // String implements flag.Value interface
@@ -51,7 +52,7 @@ func (l *labelFlags) String() string {
 }
 
 // Set implements flag.Value interface
-//nolint: gomnd
+// nolint: gomnd
 func (l *labelFlags) Set(value string) error {
 	// account for comma-separated key-value pairs in a single invocation
 	if len(strings.Split(value, ",")) > 1 {

--- a/apis/infrastructure/v1beta1/byohost_webhook.go
+++ b/apis/infrastructure/v1beta1/byohost_webhook.go
@@ -25,7 +25,7 @@ type ByoHostValidator struct {
 // To allow byoh manager service account to patch ByoHost CR
 const managerServiceAccount = "system:serviceaccount:byoh-system:byoh-controller-manager"
 
-//nolint: gocritic
+// nolint: gocritic
 // Handle handles all the requests for ByoHost resource
 func (v *ByoHostValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var response admission.Response

--- a/apis/infrastructure/v1beta1/byohost_webhook.go
+++ b/apis/infrastructure/v1beta1/byohost_webhook.go
@@ -25,7 +25,7 @@ type ByoHostValidator struct {
 // To allow byoh manager service account to patch ByoHost CR
 const managerServiceAccount = "system:serviceaccount:byoh-system:byoh-controller-manager"
 
-// nolint: gocritic
+//nolint: gocritic
 // Handle handles all the requests for ByoHost resource
 func (v *ByoHostValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var response admission.Response
@@ -56,8 +56,8 @@ func (v *ByoHostValidator) handleCreateUpdate(req *admission.Request) admission.
 	if len(substrs) < 2 { //nolint: gomnd
 		return admission.Denied(fmt.Sprintf("%s is not a valid agent username", userName))
 	}
-	if !strings.Contains(byoHost.Name, substrs[2]) {
-		return admission.Denied(fmt.Sprintf("%s cannot create/update resource %s", userName, byoHost.Name))
+	// if !strings.Contains(byoHost.Name, substrs[2]) {
+	// 	return admission.Denied(fmt.Sprintf("%s cannot create/update resource %s", userName, byoHost.Name))
 	}
 	return admission.Allowed("")
 }

--- a/apis/infrastructure/v1beta1/groupversion_info.go
+++ b/apis/infrastructure/v1beta1/groupversion_info.go
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package v1beta1 contains API Schema definitions for the infrastructure v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=infrastructure.cluster.x-k8s.io
+// +kubebuilder:object:generate=true
+// +groupName=infrastructure.cluster.x-k8s.io
 package v1beta1
 
 import (

--- a/controllers/infrastructure/k8sinstallerconfig_controller.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller.go
@@ -169,9 +169,12 @@ func (r *K8sInstallerConfigReconciler) storeInstallationData(ctx context.Context
 	logger := scope.Logger
 	logger.Info("creating installation secret")
 
+	// Currently the secret name is set to byomachine name, but both kubeadm control plan
+	// & byoh try to create secret with same name. Changing secret name
+	secretName := "byoinstall-" + scope.Config.Name
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      scope.Config.Name,
+			Name:      secretName,
 			Namespace: scope.Config.Namespace,
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: scope.Cluster.Name,

--- a/controllers/infrastructure/k8sinstallerconfig_controller.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller.go
@@ -169,8 +169,6 @@ func (r *K8sInstallerConfigReconciler) storeInstallationData(ctx context.Context
 	logger := scope.Logger
 	logger.Info("creating installation secret")
 
-	// Currently the secret name is set to byomachine name, but both kubeadm control plan
-	// & byoh try to create secret with same name. Changing secret name
 	secretName := "byoinstall-" + scope.Config.Name
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/docs/sample/cluster.yaml
+++ b/docs/sample/cluster.yaml
@@ -1,0 +1,218 @@
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: byoh-cluster-md-0
+  namespace: byoh
+spec:
+  template:
+    spec: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cni: byoh-cluster-crs-0
+    crs: "true"
+  name: byoh-cluster
+  namespace: byoh
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 10.128.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: byoh-cluster-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: ByoCluster
+    name: byoh-cluster
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: byoh-cluster-md-0
+  namespace: byoh
+spec:
+  clusterName: byoh-cluster
+  replicas: 1
+  selector:
+    matchLabels: null
+  template:
+    metadata:
+      labels:
+        nodepool: pool1
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: byoh-cluster-md-0
+      clusterName: byoh-cluster
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: ByoMachineTemplate
+        name: byoh-cluster-md-0
+      version: v1.26.6
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  labels:
+    nodepool: pool0
+  name: byoh-cluster-control-plane
+  namespace: byoh
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
+        - host.docker.internal
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: cp_enable
+              value: "true"
+            - name: vip_arp
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_address
+              value: 10.149.106.217
+            - name: vip_interface
+              value: {{ .DefaultNetworkInterfaceName }}
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            image: ghcr.io/kube-vip/kube-vip:v0.5.0
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          hostAliases:
+            - hostnames:
+                - kubernetes
+              ip: 127.0.0.1
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+              type: FileOrCreate
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: ByoMachineTemplate
+      name: byoh-cluster-control-plane
+      namespace: byoh
+  replicas: 1
+  version: v1.26.6
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoCluster
+metadata:
+  name: byoh-cluster
+  namespace: byoh
+spec:
+  bundleLookupBaseRegistry: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+  controlPlaneEndpoint:
+    host: 10.149.106.217
+    port: 6443
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: byoh-cluster-control-plane
+  namespace: byoh
+spec:
+  template:
+    spec:
+      installerRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: K8sInstallerConfigTemplate
+        name: byoh-cluster-control-plane
+        namespace: byoh
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: byoh-cluster-md-0
+  namespace: byoh
+spec:
+  template:
+    spec:
+      installerRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: K8sInstallerConfigTemplate
+        name: byoh-cluster-md-0
+        namespace: byoh
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: K8sInstallerConfigTemplate
+metadata:
+  name: byoh-cluster-control-plane
+  namespace: byoh
+spec:
+  template:
+    spec:
+      bundleRepo: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+      bundleType: k8s
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: K8sInstallerConfigTemplate
+metadata:
+  name: byoh-cluster-md-0
+  namespace: byoh
+spec:
+  template:
+    spec:
+      bundleRepo: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+      bundleType: k8s

--- a/docs/sample/generate-bootstrap-config.sh
+++ b/docs/sample/generate-bootstrap-config.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/bash
+
+NAMESPACE=byoh
+SERVICE_ACCOUNT=default
+CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
+CLUSTER_SERVER=https://10.149.106.220:443
+SECRET_NAME=$(kubectl get secret -n $NAMESPACE -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\.io/service-account\.name']=='$SERVICE_ACCOUNT')].metadata.name}")
+CA_DATA=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.ca\.crt}')
+TOKEN=$(kubectl get secret $SECRET_NAME -n $NAMESPACE -o jsonpath='{.data.token}' | base64 --decode)
+
+cat <<EOF > bootstrap-kubeconfig.yaml
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: ${CA_DATA}
+    server: ${CLUSTER_SERVER}
+  name: ${CLUSTER_NAME}
+contexts:
+- context:
+    cluster: ${CLUSTER_NAME}
+    namespace: ${NAMESPACE}
+    user: ${SERVICE_ACCOUNT}
+  name: ${SERVICE_ACCOUNT}-${NAMESPACE}
+current-context: ${SERVICE_ACCOUNT}-${NAMESPACE}
+users:
+- name: ${SERVICE_ACCOUNT}
+  user:
+    token: ${TOKEN}
+EOF
+

--- a/docs/sample/kamaji_clusterrolebindings.yaml
+++ b/docs/sample/kamaji_clusterrolebindings.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: byo-cluster-patch-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: capi-kamaji-controller-manager
+  namespace: kamaji-system
+roleRef:
+  kind: ClusterRole
+  name: byo-cluster-patch-clusterrole
+  apiGroup: rbac.authorization.k8s.io
+

--- a/docs/sample/kamaji_clusterroles.yaml
+++ b/docs/sample/kamaji_clusterroles.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: byo-cluster-patch-clusterrole
+rules:
+- apiGroups: ["infrastructure.cluster.x-k8s.io"]
+  resources: ["byoclusters", "byoclusters/status"]
+  verbs: ["patch"]
+

--- a/docs/sample/rbac_csr.yaml
+++ b/docs/sample/rbac_csr.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: byoh
+  name: certificate-manager
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["create", "get", "list", "watch", "approve", "issue"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: bind-certificate-manager
+  namespace: byoh
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: byoh
+roleRef:
+  kind: Role
+  name: certificate-manager
+  apiGroup: rbac.authorization.k8s.io
+

--- a/docs/sample/rolebinding.yaml
+++ b/docs/sample/rolebinding.yaml
@@ -1,0 +1,39 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: default-binding
+  namespace: byoh
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: byoh
+roleRef:
+  kind: Role
+  name: default
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csr-manager-binding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: byoh
+roleRef:
+  kind: ClusterRole
+  name: csr-manager
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: byohosts-clusterrolebinding
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: byoh
+roleRef:
+  kind: ClusterRole
+  name: byo-manager
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/sample/roles.yaml
+++ b/docs/sample/roles.yaml
@@ -1,0 +1,60 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: default
+  namespace: byoh
+rules:
+- apiGroups: [""]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["apps"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["extensions"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["batch"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["autoscaling"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["*"]
+  verbs: ["*"]
+- apiGroups: ["rbac.authorization.k8s.io"]
+  resources: ["roles", "rolebindings"]
+  verbs: ["*"]
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["create", "get", "list", "watch", "approve"]
+- apiGroups: ["infrastructure.cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io/v1beta1"]
+  resources: ["byohosts", "byohost"]
+  verbs: ["create", "update", "get", "list", "watch", "delete", "patch"]
+- apiGroups: ["infrastructure.cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io/v1beta1"]
+  resources: ["byohosts/status", "byohost/status"]
+  verbs: ["patch", "update"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csr-manager
+rules:
+- apiGroups: ["certificates.k8s.io"]
+  resources: ["certificatesigningrequests"]
+  verbs: ["create", "get", "list", "watch", "approve", "issue"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: byo-manager
+rules:
+- apiGroups: ["infrastructure.cluster.x-k8s.io", "infrastructure.cluster.x-k8s.io/v1beta1"]
+  resources: ["byohosts", "byohost"]
+  verbs: ["create", "update", "get", "list", "watch", "delete", "patch"]
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "watch"]

--- a/docs/sample/sa.yaml
+++ b/docs/sample/sa.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: default
+  namespace: byoh
+

--- a/docs/sample/secret.yaml
+++ b/docs/sample/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: default-token
+  namespace: byoh
+  annotations:
+    kubernetes.io/service-account.name: default
+type: kubernetes.io/service-account-token
+

--- a/installer/bundle_builder/Dockerfile
+++ b/installer/bundle_builder/Dockerfile
@@ -16,7 +16,7 @@
 # // Build and store a BYOH bundle
 # docker run --rm -v <INGREDIENTS_HOST_ABS_PATH>:/ingredients  -v <BUNDLE_OUTPUT_ABS_PATH>:/bundle --env <THIS_IMAGE>
 
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/k14s/image
+FROM k14s/image
 
 # If set to 1 bundle is built and available as bundle/bundle.tar
 # If set to 0 bundle is build and pushed to repo

--- a/installer/bundle_builder/build-bundle.sh
+++ b/installer/bundle_builder/build-bundle.sh
@@ -33,5 +33,9 @@ cp $CONFIG_PATH/conf.tar .
 
 echo Creating bundle tar
 tar -cvf /bundle/bundle.tar *
-
+echo "TEST====="
+ls $PWD
+mkdir -p $INGREDIENTS_PATH/imgpkg_dir
+cp *.* $INGREDIENTS_PATH/imgpkg_dir/
+echo "TEST====="
 echo Done

--- a/installer/bundle_builder/build-push-bundle.sh
+++ b/installer/bundle_builder/build-push-bundle.sh
@@ -3,7 +3,7 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 build-bundle.sh $1 $2
 if [ $BUILD_ONLY -eq 0 ]

--- a/installer/bundle_builder/ingredients/deb/Dockerfile
+++ b/installer/bundle_builder/ingredients/deb/Dockerfile
@@ -13,11 +13,12 @@ FROM $BASE_IMAGE as build
 
 # Override to download other version
 ENV CONTAINERD_VERSION=1.6.26
-ENV KUBERNETES_VERSION=1.26.6-00
+ENV KUBERNETES_VERSION=1.26.6-1.1
+ENV KUBERNETES_MAJOR_VERSION=v1.26
 ENV ARCH=amd64
 
 RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends sudo
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends sudo gnupg
 
 WORKDIR /bundle-builder
 COPY download.sh .

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -9,14 +9,16 @@ echo  Update the apt package index and install packages needed to use the Kubern
 sudo apt-get update
 sudo apt-get install -y apt-transport-https ca-certificates curl
 
+mkdir -p /etc/apt/keyrings/
+
 echo Download containerd
 curl -LOJR https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz
 
 echo Download the Google Cloud public signing key
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
+curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBERENETES_MAJOR_VERSION}/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
 echo Add the Kubernetes apt repository
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERENETES_MAJOR_VERSION}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 
 echo Update apt package index, install kubelet, kubeadm and kubectl
 sudo apt-get update

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -3,7 +3,7 @@
 # Copyright 2021 VMware, Inc. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+set -ex
 
 echo Pushing bundle "$*"
 


### PR DESCRIPTION
This PR fixes [KAAP-283](https://platform9.atlassian.net/browse/KAAP-283)

Fixes:
1. This changes the username from `default-auth` to the one in bootstrap kubeconfig.

2. Edited create/update function to exclude the hostname check. This check is causing issues in our case. The previous code required the username to include the hostname in it for update/create. Since we don't follow that pattern, it was causing issues.

3. Changed the Installationsecret name to byoinstall-* so that it won't interfere with `bootstrapSecret`.

Testing: yet to be done


[KAAP-283]: https://platform9.atlassian.net/browse/KAAP-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the BYOH system by updating authentication to use service account names, removing problematic hostname validation, and modifying installation secret naming. The changes include new sample configurations, documentation updates, and Kubernetes package repository modifications. The PR also implements infrastructure updates and code style improvements for better maintainability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 4
</div>