### PR TITLE
Add byoh-bundle generator for k8s version 

### DIFF
--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -1,0 +1,34 @@
+set -ex
+echo 'alias shasum="sha512sum"' >> ~/.bashrc
+source ~/.bashrc
+
+export BUILD_ONLY
+export CONTAINERD_VERSION 
+export KUBERNETES_VERSION
+export KUBERNETES_MAJOR_VERSION
+export ARCH
+
+#alias shasum="sha512sum"
+echo "installing imgpkg"
+curl -LO https://github.com/carvel-dev/imgpkg/releases/download/v0.43.1/imgpkg-linux-amd64
+mv imgpkg-linux-amd64 installer/bundle_builder/imgpkg
+chmod +x installer/bundle_builder/imgpkg
+
+cd installer/bundle_builder
+
+echo "building docker image to create byoh-bundle"
+docker build -t byoh-bundle .
+docker rm -f byoh-bundle-container
+
+echo "executing docker image"
+docker run -e BUILD_ONLY -e CONTAINERD_VERSION -e KUBERNETES_VERSION -e KUBERNETES_MAJOR_VERSION -e ARCH --name byoh-bundle-container -i byoh-bundle /bin/bash
+
+echo "creating bundle dir to push k8s packages"
+mkdir -p ./bundle
+
+echo "coping bundle from docker image"
+docker cp byoh-bundle-container:/bundle ./bundle
+
+echo "pushing oci bundle to quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s"
+./imgpkg push -f ./bundle -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_VERSION
+

--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -2,11 +2,13 @@ set -ex
 echo 'alias shasum="sha512sum"' >> ~/.bashrc
 source ~/.bashrc
 
-export BUILD_ONLY
-export CONTAINERD_VERSION 
-export KUBERNETES_VERSION
-export KUBERNETES_MAJOR_VERSION
-export ARCH
+
+export BUILD_ONLY=${BUILD_ONLY:-1}
+export CONTAINERD_VERSION=${CONTAINERD_VERSION:-1.7.26}
+export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.31.0-1.1}
+export KUBERNETES_MAJOR_VERSION=${KUBERNETES_MAJOR_VERSION:-v1.31}
+export ARCH=${ARCH:-amd64}
+export CNI_VERSION=${CNI_VERSION:-1.4.0-1.1}
 
 #alias shasum="sha512sum"
 echo "installing imgpkg"

--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -6,9 +6,9 @@ source ~/.bashrc
 export BUILD_ONLY=${BUILD_ONLY:-1}
 export CONTAINERD_VERSION=${CONTAINERD_VERSION:-1.7.26}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.31.0-1.1}
-export KUBERNETES_MAJOR_VERSION=${KUBERNETES_MAJOR_VERSION:-v1.31}
+export KUBERNETES_MAJOR_VERSION=${KUBERNETES_MAJOR_VERSION:-v1.31.0}
 export ARCH=${ARCH:-amd64}
-export CNI_VERSION=${CNI_VERSION:-1.4.0-1.1}
+# export CNI_VERSION=${CNI_VERSION:-1.4.0-1.1}
 
 #alias shasum="sha512sum"
 echo "installing imgpkg"
@@ -32,5 +32,5 @@ echo "coping bundle from docker image"
 docker cp byoh-bundle-container:/bundle ./bundle
 
 echo "pushing oci bundle to quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s"
-./imgpkg push -f ./bundle -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_VERSION
+./imgpkg push -f ./bundle -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 

--- a/installer/bundle_builder/Dockerfile
+++ b/installer/bundle_builder/Dockerfile
@@ -20,12 +20,6 @@ FROM ubuntu:20.04
 
 # If set to 1 bundle is built and available as bundle/bundle.tar
 # If set to 0 bundle is build and pushed to repo
-ENV BUILD_ONLY=1
-ENV CONTAINERD_VERSION=1.6.26
-ENV KUBERNETES_VERSION=1.31.0-1.1
-ENV KUBERNETES_MAJOR_VERSION=v1.31
-ENV ARCH=amd64
-ENV BUILD_ONLY=1
 
 RUN apt-get update && apt-get install -y gpg \
     curl \

--- a/installer/bundle_builder/Dockerfile
+++ b/installer/bundle_builder/Dockerfile
@@ -28,7 +28,8 @@ ENV ARCH=amd64
 ENV BUILD_ONLY=1
 
 RUN apt-get update && apt-get install -y gpg \
-    curl 
+    curl \
+    libdigest-sha-perl  
 
 WORKDIR /bundle-builder
 COPY *.sh ./

--- a/installer/bundle_builder/Dockerfile
+++ b/installer/bundle_builder/Dockerfile
@@ -16,20 +16,30 @@
 # // Build and store a BYOH bundle
 # docker run --rm -v <INGREDIENTS_HOST_ABS_PATH>:/ingredients  -v <BUNDLE_OUTPUT_ABS_PATH>:/bundle --env <THIS_IMAGE>
 
-FROM harbor-repo.vmware.com/dockerhub-proxy-cache/k14s/image
+FROM ubuntu:20.04 
 
 # If set to 1 bundle is built and available as bundle/bundle.tar
 # If set to 0 bundle is build and pushed to repo
 ENV BUILD_ONLY=1
+ENV CONTAINERD_VERSION=1.6.26
+ENV KUBERNETES_VERSION=1.31.0-1.1
+ENV KUBERNETES_MAJOR_VERSION=v1.31
+ENV ARCH=amd64
+ENV BUILD_ONLY=1
+
+RUN apt-get update && apt-get install -y gpg \
+    curl 
 
 WORKDIR /bundle-builder
 COPY *.sh ./
-RUN chmod a+x *.sh
 #Default config
 COPY config/ubuntu/20_04/k8s/1_22 /config/
+COPY ingredients/deb/download.sh download.sh
 
+RUN chmod a+x *.sh
 RUN mkdir /ingredients && mkdir /bundle
+
 ENV PATH="/bundle-builder:${PATH}"
 
-WORKDIR /tmp/bundle
+WORKDIR /bundle
 ENTRYPOINT ["build-push-bundle.sh", "/ingredients", "/config"]

--- a/installer/bundle_builder/build-bundle.sh
+++ b/installer/bundle_builder/build-bundle.sh
@@ -14,6 +14,7 @@ echo Building bundle...
 echo Ingredients $INGREDIENTS_PATH
 ls -l $INGREDIENTS_PATH
 
+cd /bundle
 echo Strip version to well-known names
 # Mandatory
 cp $INGREDIENTS_PATH/*containerd* containerd.tar

--- a/installer/bundle_builder/build-push-bundle.sh
+++ b/installer/bundle_builder/build-push-bundle.sh
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-
+download.sh
+cd /bundle
 build-bundle.sh $1 $2
 if [ $BUILD_ONLY -eq 0 ]
 then

--- a/installer/bundle_builder/build-push-bundle.sh
+++ b/installer/bundle_builder/build-push-bundle.sh
@@ -6,5 +6,8 @@
 set -e
 download.sh
 build-bundle.sh $1 $2
-#push-bundle.sh 
+if [ $BUILD_ONLY -eq 0 ]
+then
+push-bundle.sh ${@:3}
+fi
 

--- a/installer/bundle_builder/build-push-bundle.sh
+++ b/installer/bundle_builder/build-push-bundle.sh
@@ -5,10 +5,6 @@
 
 set -e
 download.sh
-cd /bundle
 build-bundle.sh $1 $2
-if [ $BUILD_ONLY -eq 0 ]
-then
-push-bundle.sh ${@:3}
-fi
+push-bundle.sh 
 

--- a/installer/bundle_builder/build-push-bundle.sh
+++ b/installer/bundle_builder/build-push-bundle.sh
@@ -6,5 +6,5 @@
 set -e
 download.sh
 build-bundle.sh $1 $2
-push-bundle.sh 
+#push-bundle.sh 
 

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -6,20 +6,28 @@
 set -e
 
 echo  Update the apt package index and install packages needed to use the Kubernetes apt repository
-sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl
+ apt-get update
+ apt-get install -y apt-transport-https ca-certificates curl
 
 echo Download containerd
-curl -LOJR https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz
+curl -LOJR https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz 
 
 echo Download the Google Cloud public signing key
-sudo curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
+ curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
 
 echo Add the Kubernetes apt repository
-echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MAJOR_VERSION}/deb/ /" |  tee /etc/apt/sources.list.d/kubernetes.list
+
+mkdir -p /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MAJOR_VERSION}/deb/Release.key |  gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
 echo Update apt package index, install kubelet, kubeadm and kubectl
-sudo apt-get update
-sudo apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
-sudo apt-get download kubernetes-cni:$ARCH=1.1.1-00
-sudo apt-get download cri-tools:$ARCH=1.25.0-00
+ apt-get update
+ chown -Rv _apt:root /bundle/
+ chown -R _apt:root /ingredients
+ mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
+ cd /ingredients 
+ apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
+ apt-get download kubernetes-cni
+ apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni:$ARCH=$CNI_VERSION
+ apt-get download kubernetes-cni:$ARCH=1.4.1-1.1
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni
+ apt-get download kubernetes-cni:$ARCH=v1.0.0
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni
+ apt-get download kubernetes-cni:$ARCH=$CNI_VERSION
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni:$ARCH=v1.0.0
+ apt-get download kubernetes-cni
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni:amd64=1.4.1-1.1
+ apt-get download kubernetes-cni:$ARCH=1.1.1-00
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni:$ARCH=1.4.1-1.1
+ apt-get download kubernetes-cni:amd64=1.4.1-1.1
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -29,5 +29,5 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
  mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
  cd /ingredients 
  apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
- apt-get download kubernetes-cni:$ARCH=1.1.1-00
+ apt-get download kubernetes-cni
  apt-get download cri-tools:$ARCH=$KUBERNETES_VERSION

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -9,6 +9,6 @@ curl -L https://carvel.dev/install.sh | bash
 export PATH=$PATH:/usr/local/bin
 imgpkg version
 
-imgpkg push -f . -i docker.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:latest
+imgpkg push -f . -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:latest
 
 echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -4,11 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
-echo install imgpkg
-curl -L https://carvel.dev/install.sh | bash
-export PATH=$PATH:/usr/local/bin
-imgpkg version
 
-imgpkg push -f . -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:latest
+echo Pushing bundle "$*"
 
-echo "bundle push done"
+imgpkg push -f . -i $@
+
+echo Done

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -5,8 +5,6 @@
 
 set -e
 
-echo Pushing bundle "$*"
-
 imgpkg push -f . -i snhpf9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 
-echo Done
+echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -9,6 +9,6 @@ curl -L https://carvel.dev/install.sh | bash
 export PATH=$PATH:/usr/local/bin
 imgpkg version
 
-imgpkg push -f . -i docker.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
+imgpkg push -f . -i platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 
 echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -9,6 +9,6 @@ curl -L https://carvel.dev/install.sh | bash
 export PATH=$PATH:/usr/local/bin
 imgpkg version
 
-imgpkg push -f . -i quay.io/platform9/pf9-byoh/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
+imgpkg push -f . -i docker.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 
 echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -9,6 +9,6 @@ curl -L https://carvel.dev/install.sh | bash
 export PATH=$PATH:/usr/local/bin
 imgpkg version
 
-imgpkg push -f . -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
+imgpkg push -f . -i docker.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:latest
 
 echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -9,6 +9,6 @@ curl -L https://carvel.dev/install.sh | bash
 export PATH=$PATH:/usr/local/bin
 imgpkg version
 
-imgpkg push -f . -i platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
+imgpkg push -f . -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 
 echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -9,6 +9,6 @@ curl -L https://carvel.dev/install.sh | bash
 export PATH=$PATH:/usr/local/bin
 imgpkg version
 
-imgpkg push -f . -i snhpf9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
+imgpkg push -f . -i quay.io/platform9/pf9-byoh/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 
 echo "bundle push done"

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -7,6 +7,6 @@ set -e
 
 echo Pushing bundle "$*"
 
-imgpkg push -f . -i $@
+imgpkg push -f . -i snhpf9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 
 echo Done

--- a/installer/bundle_builder/push-bundle.sh
+++ b/installer/bundle_builder/push-bundle.sh
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set -e
+echo install imgpkg
+curl -L https://carvel.dev/install.sh | bash
+export PATH=$PATH:/usr/local/bin
+imgpkg version
 
 imgpkg push -f . -i snhpf9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
 


### PR DESCRIPTION
BYOH-BUNDLE is a OCI image needed by byohost-agent  to connect with byocluster , this image have required packages mentioned below , which will onboard a host machine to kube cluster (byo-cluster) . 

bundle has deb packages : containerd , kubeadm ,kubelet , kubectl , cri-tool , kubernetes-cni , conf support of ubuntu 20.4

**Added changes to below files to automate bundle creation and added teamcity build for the same .**

quay repo to get OCI image [here](https://quay.io/repository/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s?tab=tags&tag=latest)

teamcity link : https://teamcity.platform9.horse/buildConfiguration/Pf9project_Platform9Components_ByohBundle_2?mode=builds 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR introduces BYOH-BUNDLE v1.31, enhancing the bundle creation workflow through improved version management and automation. It updates the Dockerfile with a new base image and refined environment settings, optimizes the build-push process with precise versioning, and simplifies package download procedures to reduce dependencies while ensuring consistent environment parameter usage.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>