### PR TITLE
Added variable to pick byohImage from TC build

### DIFF
--- a/chart-generator/byoh-chart/kustomization.yaml
+++ b/chart-generator/byoh-chart/kustomization.yaml
@@ -41,6 +41,9 @@ patchesStrategicMerge:
 # 'CERTMANAGER' needs to be enabled to use ca injection
 - webhookcainjection_patch.yaml
 
+- manager_extraconfig_patch.yaml
+
+
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.

--- a/chart-generator/byoh-chart/manager_extraconfig_patch.yaml
+++ b/chart-generator/byoh-chart/manager_extraconfig_patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        image: "{{ .Values.byohImage }}"


### PR DESCRIPTION
This PR reads the `byohImage` value from TC build dependency using kustomize patch.

Testing:

Built an capi chart with the edited byoh-chart from this private branch and upgraded an existing setup.

We see that the patch is being applied:
```
client.go:693: [debug] Patch Service "kaapi-management-plane-kamaji-metrics-service" in namespace kaapi
client.go:693: [debug] Patch Service "kaapi-management-plane-kamaji-webhook-service" in namespace kaapi
client.go:684: [debug] Looks like there are no changes for Service "webhook-service"
client.go:684: [debug] Looks like there are no changes for Service "mysql"
client.go:684: [debug] Looks like there are no changes for Deployment "barista-controller-manager"
client.go:693: [debug] Patch Deployment "byoh-controller-manager" in namespace kaapi
client.go:684: [debug] Looks like there are no changes for Deployment "kaapi-management-plane-cluster-api-operator"
client.go:684: [debug] Looks like there are no changes for Deployment "hcp-controller-manager"
client.go:693: [debug] Patch Deployment "kaapi-management-plane-kamaji" in namespace kaapi
client.go:684: [debug] Looks like there are no changes for Deployment "addon-controller"
client.go:684: [debug] Looks like there are no changes for Deployment "access-manager"
```
and the image is getting reflected in byoh-controller-pod:

```
    env:
    - name: MANUAL_CSR_APPROVAL
      value: ${MANUAL_CSR_APPROVAL:=disable}
    image: 703671907089.dkr.ecr.us-west-2.amazonaws.com/quay.io/platform9/byoh-controller-manager:0.1.14
    imagePullPolicy: IfNotPresent
    name: manager
    ports:
    - containerPort: 9443
      name: webhook-server
      protocol: TCP
```