### PR TITLE
Fixed byoh-bundle nested directory

### DIFF
--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -6,7 +6,8 @@ source ~/.bashrc
 export BUILD_ONLY=${BUILD_ONLY:-1}
 export CONTAINERD_VERSION=${CONTAINERD_VERSION:-1.7.26}
 export KUBERNETES_VERSION=${KUBERNETES_VERSION:-1.31.0-1.1}
-export KUBERNETES_MAJOR_VERSION=${KUBERNETES_MAJOR_VERSION:-v1.31.0}
+export KUBERNETES_MAJOR_VERSION=${KUBERNETES_MAJOR_VERSION:-v1.31}
+export BUNDLE_VERSION=${BUNDLE_VERSION:-v1.31.0}
 export ARCH=${ARCH:-amd64}
 # export CNI_VERSION=${CNI_VERSION:-1.4.0-1.1}
 
@@ -29,8 +30,8 @@ echo "creating bundle dir to push k8s packages"
 mkdir -p ./bundle
 
 echo "coping bundle from docker image"
-docker cp byoh-bundle-container:/bundle ./bundle
+docker cp byoh-bundle-container:/bundle/. ./bundle/
 
 echo "pushing oci bundle to quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s"
-./imgpkg push -f ./bundle -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$KUBERNETES_MAJOR_VERSION
+./imgpkg push -f ./bundle -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:$BUNDLE_VERSION
 


### PR DESCRIPTION
byo-agent was unable to get path to the deb packages , removed nested directory to fix it . 
 Testing notes 
``` 
imgpkg pull -i quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.31.0 -o /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.31.0
+ swapoff -a
+ sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+ command -v ufw
+ ufw disable
Firewall stopped and disabled on system startup
+ modprobe overlay
+ modprobe br_netfilter
+ tar -C / -xvf /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.31.0/conf.tar
etc/
etc/modules-load.d/
etc/modules-load.d/containerd.conf
etc/sysctl.d/
etc/sysctl.d/99-kubernetes-cri.conf
+ sysctl --system
* Applying /etc/sysctl.d/10-console-messages.conf ...
kernel.printk = 4 4 1 7
* Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
net.ipv6.conf.all.use_tempaddr = 2
net.ipv6.conf.default.use_tempaddr = 2
* Applying /etc/sysctl.d/10-kernel-hardening.conf ...
kernel.kptr_restrict = 1
* Applying /etc/sysctl.d/10-link-restrictions.conf ...
fs.protected_hardlinks = 1
fs.protected_symlinks = 1
* Applying /etc/sysctl.d/10-magic-sysrq.conf ...
kernel.sysrq = 176
* Applying /etc/sysctl.d/10-network-security.conf ...
net.ipv4.conf.default.rp_filter = 2
net.ipv4.conf.all.rp_filter = 2
* Applying /etc/sysctl.d/10-ptrace.conf ...
kernel.yama.ptrace_scope = 1
* Applying /etc/sysctl.d/10-zeropage.conf ...
vm.mmap_min_addr = 65536
* Applying /usr/lib/sysctl.d/50-default.conf ...
net.ipv4.conf.default.promote_secondaries = 1
sysctl: setting key "net.ipv4.conf.all.promote_secondaries": Invalid argument
net.ipv4.ping_group_range = 0 2147483647
net.core.default_qdisc = fq_codel
fs.protected_regular = 1
fs.protected_fifos = 1
* Applying /usr/lib/sysctl.d/50-pid-max.conf ...
kernel.pid_max = 4194304
* Applying /etc/sysctl.d/99-cloudimg-ipv6.conf ...
net.ipv6.conf.all.use_tempaddr = 0
net.ipv6.conf.default.use_tempaddr = 0
* Applying /etc/sysctl.d/99-kubernetes-cri.conf ...
net.bridge.bridge-nf-call-iptables = 1
net.ipv4.ip_forward = 1
net.bridge.bridge-nf-call-ip6tables = 1
* Applying /etc/sysctl.d/99-sysctl.conf ...
* Applying /usr/lib/sysctl.d/protect-links.conf ...
fs.protected_fifos = 1
fs.protected_hardlinks = 1
fs.protected_regular = 2
fs.protected_symlinks = 1
* Applying /etc/sysctl.conf ...
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.31.0/cri-tools.deb
Selecting previously unselected package cri-tools.
(Reading database ... 95194 files and directories currently installed.)
Preparing to unpack .../cri-tools.deb ...
Unpacking cri-tools (1.31.0-1.1) ...
Setting up cri-tools (1.31.0-1.1) ...
+ apt-mark hold cri-tools
cri-tools set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.31.0/kubernetes-cni.deb
Selecting previously unselected package kubernetes-cni.
(Reading database ... 95198 files and directories currently installed.)
Preparing to unpack .../kubernetes-cni.deb ...
Unpacking kubernetes-cni (1.5.1-1.1) ...
root@byoh-node:/home/ubuntu# 
```