### PR TITLE
Added versioning for byohctl

### DIFF
--- a/cmd/byohctl/Makefile
+++ b/cmd/byohctl/Makefile
@@ -1,0 +1,84 @@
+# Copyright 2023 Platform9 Systems, Inc.
+#
+# Usage:
+# make              # builds the binary for current platform
+# make build        # builds for linux/amd64
+# make build-all    # builds for all supported platforms
+# make clean        # removes build artifacts
+# make test         # runs tests
+
+SHELL := /usr/bin/env bash
+
+# Version information
+BUILD_NUMBER ?= 1
+GITHASH := $(shell git rev-parse --short HEAD)
+VERSION ?= 1.0.0
+FULL_VERSION := $(VERSION)-$(BUILD_NUMBER)-$(GITHASH)
+
+# Build settings
+BINARY_NAME := byohctl
+BUILD_DIR := $(shell pwd)/bin
+GOOS ?= linux
+GOARCH ?= amd64
+CGO_ENABLED ?= 0
+
+# LDFLAGS for version information
+LDFLAGS := -X main.buildVersion=$(FULL_VERSION) \
+           -X main.buildCommit=$(GITHASH) \
+           -s -w
+
+# Default target
+.PHONY: all
+all: build
+
+# Create build directory
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
+# Build the binary
+.PHONY: build
+build: $(BUILD_DIR)
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=$(GOOS) GOARCH=$(GOARCH) go build -o $(BUILD_DIR)/$(BINARY_NAME) -ldflags "$(LDFLAGS)"
+
+# Build for multiple platforms
+.PHONY: build-all
+build-all: $(BUILD_DIR)
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=amd64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-linux-amd64 -ldflags "$(LDFLAGS)"
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=linux GOARCH=arm64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-linux-arm64 -ldflags "$(LDFLAGS)"
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=amd64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-amd64 -ldflags "$(LDFLAGS)"
+	CGO_ENABLED=$(CGO_ENABLED) GOOS=darwin GOARCH=arm64 go build -o $(BUILD_DIR)/$(BINARY_NAME)-darwin-arm64 -ldflags "$(LDFLAGS)"
+
+# Format code
+.PHONY: format
+format:
+	gofmt -w -s *.go
+	gofmt -w -s */*.go
+
+# Run tests
+.PHONY: test
+test:
+	go test -v ./...
+
+# Clean build artifacts
+.PHONY: clean
+clean:
+	rm -rf $(BUILD_DIR)
+
+# Help target
+.PHONY: help
+help:
+	@echo "Available targets:"
+	@echo "  build       - Build for specified GOOS/GOARCH (default: linux/amd64)"
+	@echo "  build-all   - Build for multiple platforms"
+	@echo "  clean       - Remove build artifacts"
+	@echo "  format      - Format Go code"
+	@echo "  test        - Run tests"
+	@echo ""
+	@echo "Usage:"
+	@echo "  make build                    # Build for linux/amd64"
+	@echo "  make build GOOS=darwin        # Build for macOS"
+	@echo "  make build-all                # Build for all platforms"
+	@echo "  make build VERSION=2.0.0      # Build with specific version"
+	@echo ""
+	@echo "Version: $(FULL_VERSION)"
+	@echo "Output directory: $(BUILD_DIR)/"

--- a/cmd/byohctl/Makefile
+++ b/cmd/byohctl/Makefile
@@ -10,10 +10,10 @@
 SHELL := /usr/bin/env bash
 
 # Version information
+MAJOR ?= 1
+MINOR ?= 0
 BUILD_NUMBER ?= 1
-GITHASH := $(shell git rev-parse --short HEAD)
-VERSION ?= 1.0.0
-FULL_VERSION := $(VERSION)-$(BUILD_NUMBER)-$(GITHASH)
+VERSION := $(MAJOR).$(MINOR).$(BUILD_NUMBER)
 
 # Build settings
 BINARY_NAME := byohctl
@@ -23,8 +23,7 @@ GOARCH ?= amd64
 CGO_ENABLED ?= 0
 
 # LDFLAGS for version information
-LDFLAGS := -X main.buildVersion=$(FULL_VERSION) \
-           -X main.buildCommit=$(GITHASH) \
+LDFLAGS := -X main.buildVersion=$(VERSION) \
            -s -w
 
 # Default target
@@ -78,7 +77,7 @@ help:
 	@echo "  make build                    # Build for linux/amd64"
 	@echo "  make build GOOS=darwin        # Build for macOS"
 	@echo "  make build-all                # Build for all platforms"
-	@echo "  make build VERSION=2.0.0      # Build with specific version"
+	@echo "  make build MAJOR=2 MINOR=1    # Build version 2.1.BUILD_NUMBER"
 	@echo ""
-	@echo "Version: $(FULL_VERSION)"
+	@echo "Version: $(VERSION)"
 	@echo "Output directory: $(BUILD_DIR)/"

--- a/cmd/byohctl/cmd/version.go
+++ b/cmd/byohctl/cmd/version.go
@@ -12,7 +12,7 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version information",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("byohctl version:", version.GetVersion())
+		fmt.Print(version.GetVersion())
 	},
 }
 

--- a/cmd/byohctl/cmd/version.go
+++ b/cmd/byohctl/cmd/version.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/platform9/cluster-api-provider-bringyourownhost/cmd/byohctl/version"
+	"github.com/spf13/cobra"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("byohctl version:", version.GetVersion())
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/byohctl/main.go
+++ b/cmd/byohctl/main.go
@@ -2,14 +2,32 @@
 package main
 
 import (
-    "os"
-    "github.com/platform9/cluster-api-provider-bringyourownhost/cmd/byohctl/cmd"
-    "github.com/platform9/cluster-api-provider-bringyourownhost/cmd/byohctl/utils"
+	"os"
+
+	"github.com/platform9/cluster-api-provider-bringyourownhost/cmd/byohctl/cmd"
+	"github.com/platform9/cluster-api-provider-bringyourownhost/cmd/byohctl/utils"
+	"github.com/platform9/cluster-api-provider-bringyourownhost/cmd/byohctl/version"
 )
 
+// Version information set by linker flags
+var (
+	buildVersion string
+	buildCommit  string
+)
+
+func init() {
+	// Set version information
+	if buildVersion != "" {
+		version.Version = buildVersion
+	}
+	if buildCommit != "" {
+		version.GitCommit = buildCommit
+	}
+}
+
 func main() {
-    if err := cmd.Execute(); err != nil {
-        utils.LogError("Command execution failed: %s", err.Error())
-        os.Exit(1)
-    }
+	if err := cmd.Execute(); err != nil {
+		utils.LogError("Command execution failed: %s", err.Error())
+		os.Exit(1)
+	}
 }

--- a/cmd/byohctl/main.go
+++ b/cmd/byohctl/main.go
@@ -10,18 +10,12 @@ import (
 )
 
 // Version information set by linker flags
-var (
-	buildVersion string
-	buildCommit  string
-)
+var buildVersion string
 
 func init() {
 	// Set version information
 	if buildVersion != "" {
 		version.Version = buildVersion
-	}
-	if buildCommit != "" {
-		version.GitCommit = buildCommit
 	}
 }
 

--- a/cmd/byohctl/version/version.go
+++ b/cmd/byohctl/version/version.go
@@ -1,0 +1,20 @@
+package version
+
+var (
+	// Version is the version of byohctl
+	Version string
+
+	// GitCommit is the git commit hash
+	GitCommit string
+)
+
+// GetVersion returns the full version string
+func GetVersion() string {
+	if Version == "" {
+		Version = "dev"
+	}
+	if GitCommit != "" {
+		return Version + " (" + GitCommit + ")"
+	}
+	return Version
+}

--- a/cmd/byohctl/version/version.go
+++ b/cmd/byohctl/version/version.go
@@ -1,20 +1,12 @@
 package version
 
-var (
-	// Version is the version of byohctl
-	Version string
+// Version is the version of byohctl
+var Version string
 
-	// GitCommit is the git commit hash
-	GitCommit string
-)
-
-// GetVersion returns the full version string
+// GetVersion returns the version string
 func GetVersion() string {
-	if Version == "" {
-		Version = "dev"
-	}
-	if GitCommit != "" {
-		return Version + " (" + GitCommit + ")"
-	}
-	return Version
+    if Version == "" {
+        Version = "0.0.0"
+    }
+    return Version
 }


### PR DESCRIPTION
Added versioning for `byohctl` binary in the format {MAJOR_VERSION}.{MINOR_VERSION}.{TC_BUILD_ID}. and also added make targets to build the byohctl binary. 
Testing: 
Make build is working
```
➜  byohctl git:(private/main/jayanth/ByohctlVersioning) ✗ make build
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /Users/jayanthr/Documents/Projects/cluster-api-provider-bringyourownhost/cmd/byohctl/bin/byohctl -ldflags "-X main.buildVersion=1.0.1 -s -w"
```

and this versioning is also working fine
```
ubuntu@byo-9:~$ ./byohctl version
1.0.1
``` 
 <div id='description'>
<h3>Summary by Bito</h3>
The PR implements a versioning mechanism for byohctl binary with enhanced build functionality. New make targets support multi-platform builds, testing, formatting, and cleaning. A version command was added with proper version information injected via linker flags, improving the build process and versioning scheme.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>