### PR TITLE
KAAP-537 : BYOH enhancements (Updated flags to be consistent with cloudctl, interactive password input)

### DIFF
--- a/cmd/byohctl/cmd/root.go
+++ b/cmd/byohctl/cmd/root.go
@@ -13,6 +13,7 @@ var rootCmd = &cobra.Command{
 	Short: "BYOH control tool for Platform9",
 	Long: `BYOH (Bring Your Own Host) control tool for Platform9.
 This tool helps onboard hosts to your Platform9 deployment.`,
+	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		// Initialize loggers
 		if err := utils.InitLoggers(service.ByohDir, true); err != nil {


### PR DESCRIPTION
This PR solves:  [KAAP-537](https://platform9.atlassian.net/browse/KAAP-537)

This PR updated the flags to be in consistency with cloudctl.
Adds an  interactive way to input password in byohctl onboard command
Removed unnecessary command

Testing:
With the new byohctl command:

```
root@byo-9:/home/ubuntu# ./byohctl onboard -u vaibhavd-dev.app.dev-pcd.platform9.com -e admin@platform9.com --password-interactive -c oXW3ACCjjqKnjVZ7 -d default -t service
Enter Password: 
[2025-04-06 13:02:21] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-04-06 13:02:23] [SUCCESS] Successfully obtained authentication token
[2025-04-06 13:02:23] [SUCCESS] Successfully retrieved secret
[2025-04-06 13:02:23] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-04-06 13:02:24] [SUCCESS] All required packages installed successfully
[2025-04-06 13:02:25] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-04-06 13:02:27] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-04-06 13:02:27] [SUCCESS] Agent setup completed successfully
[2025-04-06 13:02:27] [SUCCESS] Successfully onboarded the host
[2025-04-06 13:02:27] [SUCCESS] BYOH Agent Service logs are available at:
[2025-04-06 13:02:27] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-04-06 13:02:27] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service
```

[KAAP-537]: https://platform9.atlassian.net/browse/KAAP-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR refines the byohctl onboard command by updating flag definitions and usage examples for consistency with cloudctl. It removes obsolete flag requirements, adds interactive password input, streamlines code by eliminating redundant validations, and enhances command-line completion behavior.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>