### PR TITLE
 kaap-553: Proceed with host cleanup in case of decommission even if …

### DIFF
--- a/cmd/byohctl/cmd/deauthorise.go
+++ b/cmd/byohctl/cmd/deauthorise.go
@@ -19,15 +19,18 @@ This command will:
 1. Authenticate with Platform9
 2. Deauthorise the host from the byo cluster
 3. Host must have been part of some cluster before deauthorisation`,
-	Example: `  byohctl deauthorise`,
+	Example: `  byohctl deauthorise -v all`,
 	Run:     runDeauthorise,
 }
 
 func init() {
 	rootCmd.AddCommand(deauthoriseCmd)
+	deauthoriseCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
 }
 
 func runDeauthorise(cmd *cobra.Command, args []string) {
+
+	utils.SetConsoleOutputLevel(verbosity)
 
 	namespace, err := client.GetNamespaceFromConfig(service.KubeconfigFilePath)
 	if err != nil {

--- a/cmd/byohctl/cmd/decommission.go
+++ b/cmd/byohctl/cmd/decommission.go
@@ -19,15 +19,18 @@ This command will:
 1. Authenticate with Platform9
 2. Decommission the host from the pf9 kaapi management cluster
 3. If host is part of some cluster, decommission will deauthorise the host first and then decommission`,
-	Example: `  byohctl decommission`,
+	Example: `  byohctl decommission -v all`,
 	Run:     runDecommission,
 }
 
 func init() {
 	rootCmd.AddCommand(decommissionCmd)
+	decommissionCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
 }
 
 func runDecommission(cmd *cobra.Command, args []string) {
+
+	utils.SetConsoleOutputLevel(verbosity)
 
 	namespace, err := client.GetNamespaceFromConfig(service.KubeconfigFilePath)
 	if err != nil {

--- a/cmd/byohctl/cmd/onboard.go
+++ b/cmd/byohctl/cmd/onboard.go
@@ -84,7 +84,7 @@ func runOnboard(cmd *cobra.Command, args []string) {
 	out, err := service.RunWithStdout(service.Systemctl, service.SystemctlServiceExists...)
 	if err != nil {
 		utils.LogSuccess("Byoh service is not installed, proceeding with onboarding")
-	} else if len(out) > 0 {
+	} else if strings.Contains(out, service.ByohAgentServiceName) {
 		utils.LogError("pf9-byohost-agent service is already installed on this host. Host already onboarded in some tenant.")
 		os.Exit(1)
 	}

--- a/cmd/byohctl/pkg/host_operations.go
+++ b/cmd/byohctl/pkg/host_operations.go
@@ -59,7 +59,7 @@ func PerformHostOperation(operationType HostOperationType, namespace string) err
 				return fmt.Errorf("failed to get user input: %v", err)
 			}
 			if !continueDecommission {
-				return fmt.Errorf("Info: Host decommission cancelled by user.")
+				return nil
 			}
 			err = service.PurgeDebianPackage()
 			if err != nil {
@@ -83,17 +83,7 @@ func PerformHostOperation(operationType HostOperationType, namespace string) err
 		// If deauthorise, just return
 		if operationType == OperationDecommission {
 			utils.LogInfo("MachineRef is not set to the byohost object. Host is not part of any cluster. Deleting the byohost object and running dpkg purge.")
-			err = client.DeleteByoHostObject(namespace)
-			if err != nil {
-				return fmt.Errorf("failed to delete ByoHosts object: %v", err)
-			}
-			utils.LogSuccess("Successfully deleted ByoHosts object")
-			err = service.PurgeDebianPackage()
-			if err != nil {
-				return fmt.Errorf("failed to run dpkg purge: %v", err)
-			}
-			utils.LogSuccess("Successfully ran dpkg purge")
-			return nil
+			return performHostDecommissionWithNoMachineRef(client, namespace)
 		}
 		return fmt.Errorf("machineRef is not set for the byohost object. This host is not part of the cluster. Cannot proceed ahead with de-auth")
 
@@ -160,18 +150,34 @@ func PerformHostOperation(operationType HostOperationType, namespace string) err
 
 	// If operation is decommission, delete the byohost object and run dpkg purge
 	if operationType == OperationDecommission {
-		utils.LogInfo("Deleting ByoHosts object and running dpkg purge")
-		err = client.DeleteByoHostObject(namespace)
-		if err != nil {
-			return fmt.Errorf("failed to delete ByoHosts object: %v", err)
-		}
-		err = service.PurgeDebianPackage()
-		if err != nil {
-			return fmt.Errorf("failed to run dpkg purge: %v", err)
-		}
-
-		utils.LogSuccess("Successfully deleted ByoHosts object and ran dpkg purge")
+		return performHostDecommissionWithNoMachineRef(client, namespace)
 	}
+
+	return nil
+}
+
+// Helper function to consolidate decommissioning logic when no machineRef is set
+func performHostDecommissionWithNoMachineRef(client *client.Client, namespace string) error {
+	// 1. Delete the byohost object
+	// 2. Run dpkg purge
+	// 3. Return success
+
+	utils.LogInfo("Deleting ByoHosts object and running dpkg purge")
+	// 1. Delete the byohost object
+	err := client.DeleteByoHostObject(namespace)
+	if err != nil {
+		return fmt.Errorf("failed to delete ByoHosts object: %v", err)
+	}
+
+	utils.LogSuccess("Successfully deleted ByoHosts object")
+
+	// 2. Run dpkg purge
+	err = service.PurgeDebianPackage()
+	if err != nil {
+		return fmt.Errorf("failed to run dpkg purge: %v", err)
+	}
+
+	utils.LogSuccess("Successfully ran dpkg purge")
 
 	return nil
 }


### PR DESCRIPTION
[KAAP-553](https://platform9.atlassian.net/issues/KAAP-553)

There might be a case where byohost object on the management is got deleted accidentally or manually, in such case if user does `byohctl decommission` don't fail directly. Update user and ask for host cleanup, if yes, proceed ahead with dpkg purge which further takes care of complete host side cleanup. 

```
 ~/Documents  kubectl get byohosts -A                                                                                                    
NAMESPACE                      NAME    OSNAME   OSIMAGE              ARCH
vaibhavd-dev-default-service   byo-9   linux    Ubuntu 22.04.2 LTS   amd64
```

onboard a host

```
root@test-byoh-999:~# ./byohctl onboard -f 'vaibhavd-dev.app.dev-pcd.platform9.com' -u admin@platform9.com -p s0upnaz1 -v all -t kartik --client-token oXW3ACCjjqKnjVZ7
[2025-04-06 19:26:10] [DEBUG] Starting host onboarding process
[2025-04-06 19:26:10] [DEBUG] Using FQDN: vaibhavd-dev.app.dev-pcd.platform9.com, Domain: default, Tenant: kartik
[2025-04-06 19:26:10] [DEBUG] Verbosity level set to: all
[2025-04-06 19:26:10] [DEBUG] Getting authentication token for user admin@platform9.com
[2025-04-06 19:26:10] [DEBUG] Getting authentication token for user admin@platform9.com
[2025-04-06 19:26:13] [SUCCESS] Successfully obtained authentication token
[2025-04-06 19:26:13] [DEBUG] Token retrieval took 2.204914631s
[2025-04-06 19:26:13] [INFO] Preparing directory structure for BYOH agent
[2025-04-06 19:26:13] [INFO] Saving kubeconfig from bootstrap secret
[2025-04-06 19:26:13] [INFO] Fetching secret 'byoh-bootstrap-kc'
[2025-04-06 19:26:13] [SUCCESS] Successfully retrieved secret
[2025-04-06 19:26:13] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-04-06 19:26:13] [INFO] Setting up BYOH agent
[2025-04-06 19:26:13] [INFO] Setting up BYOH agent
[2025-04-06 19:26:13] [INFO] Checking and installing required packages...
[2025-04-06 19:26:13] [INFO] Checking for required packages...
[2025-04-06 19:26:14] [SUCCESS] All required packages installed successfully
[2025-04-06 19:26:14] [INFO] Downloading agent package...
[2025-04-06 19:26:14] [INFO] Downloading BYOH agent Debian package from quay.io/platform9/byoh-agent-deb:0.1.78
[2025-04-06 19:26:16] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-04-06 19:26:16] [INFO] Installing BYOH agent package...
[2025-04-06 19:26:16] [INFO] Installing package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-04-06 19:26:17] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-04-06 19:26:17] [SUCCESS] Agent setup completed successfully
[2025-04-06 19:26:17] [SUCCESS] Successfully onboarded the host
[2025-04-06 19:26:17] [DEBUG] Time elapsed: 6.236105465s
[2025-04-06 19:26:17] [SUCCESS] BYOH Agent Service logs are available at:
[2025-04-06 19:26:17] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-04-06 19:26:17] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service
[2025-04-06 19:26:17] [DEBUG] Total onboarding process took 6.236153856s
```

```
 ~/Documents  kubectl get byohosts -A                                                                                                        
NAMESPACE                      NAME            OSNAME   OSIMAGE              ARCH
vaibhavd-dev-default-kartik    test-byoh-999   linux    Ubuntu 20.04.6 LTS   amd64
vaibhavd-dev-default-service   byo-9           linux    Ubuntu 22.04.2 LTS   amd64
```

Delete the byohost object 


```
 ~/Documents  kubectl delete byohost test-byoh-999 -n vaibhavd-dev-default-kartik                                                            ✔  app-dataplane-4 󱃾  12:57:33 AM
byohost.infrastructure.cluster.x-k8s.io "test-byoh-999" deleted
 ~/Documents  kubectl get byohosts -A                                                                                                        ✔  app-dataplane-4 󱃾  12:59:13 AM
NAMESPACE                      NAME    OSNAME   OSIMAGE              ARCH
vaibhavd-dev-default-service   byo-9   linux    Ubuntu 22.04.2 LTS   amd64
```

At this point if we do byohctl with old binary - 

```
root@byoh-kaapi-test-3:~# byohctl decommission 
[SUCCESS] Successfully retrieved Kubernetes client 
Failed to decommission host. 
failed to get ByoHosts object from the management plane: error getting ByoHosts: byohosts.infrastructure.cluster.x-k8s.io "byohost test-byoh-999" not found
```

After the changes - 

```
root@test-byoh-999:~# ./byohctl deauthorise
[2025-04-06 19:31:22] [SUCCESS] Successfully retrieved Kubernetes client
failed to get ByoHosts object from the management plane: error getting ByoHosts: byohosts.infrastructure.cluster.x-k8s.io "test-byoh-999" not found
Failed to deauthorise host. Cannot proceed ahead with the deauthorisation. Either restart the pf9-byohost-agent service or decommission and re-onboard.
root@test-byoh-999:~#
root@test-byoh-999:~#
root@test-byoh-999:~#
root@test-byoh-999:~#
root@test-byoh-999:~# ./byohctl decommission -v all
[2025-04-06 19:31:28] [INFO] Performing decommission operation for host in namespace vaibhavd-dev-default-kartik
[2025-04-06 19:31:28] [SUCCESS] Successfully retrieved Kubernetes client
failed to get ByoHosts object from the management plane: error getting ByoHosts: byohosts.infrastructure.cluster.x-k8s.io "test-byoh-999" not found
Do you want to proceed with host cleanup? (y/n): n
Failed to decommission host. Info: Host decommission cancelled by user.
root@test-byoh-999:~#
root@test-byoh-999:~#
root@test-byoh-999:~#
root@test-byoh-999:~# ./byohctl decommission -v all
[2025-04-06 19:31:33] [INFO] Performing decommission operation for host in namespace vaibhavd-dev-default-kartik
[2025-04-06 19:31:33] [SUCCESS] Successfully retrieved Kubernetes client
failed to get ByoHosts object from the management plane: error getting ByoHosts: byohosts.infrastructure.cluster.x-k8s.io "test-byoh-999" not found
Do you want to proceed with host cleanup? (y/n): y
[2025-04-06 19:31:36] [SUCCESS] Successfully purged Debian package pf9-byohost-agent
[2025-04-06 19:31:36] [SUCCESS] Successfully ran dpkg purge
[2025-04-06 19:31:36] [SUCCESS] Successfully decommissioned host from the pf9 kaapi management cluster
```



[KAAP-553]: https://platform9.atlassian.net/browse/KAAP-553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances CLI operations by updating deauthorise and decommission commands with verbosity flags and better examples. It improves the onboard command's service presence check and modifies host operations to replace abrupt error handling with user prompts for host cleanup during decommission, addressing accidental byohost object deletion issues.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
</div>