### PR TITLE
Listing only hosts from same NS to attach

### DIFF
--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -510,7 +510,10 @@ func (r *ByoMachineReconciler) attachByoHost(ctx context.Context, machineScope *
 	byohostLabels, _ := labels.NewRequirement(clusterv1.ClusterNameLabel, selection.DoesNotExist, nil)
 	selector = selector.Add(*byohostLabels)
 
-	err = r.Client.List(ctx, hostsList, &client.ListOptions{LabelSelector: selector})
+	err = r.Client.List(ctx, hostsList, &client.ListOptions{
+		LabelSelector: selector,
+		Namespace:     machineScope.ByoMachine.Namespace,
+	})
 	if err != nil {
 		logger.Error(err, "failed to list byohosts")
 		return ctrl.Result{RequeueAfter: RequeueForbyohost}, err


### PR DESCRIPTION
This PR solves [KAAP-562](https://platform9.atlassian.net/browse/KAAP-562)

Byoh controller was listing hosts from all NS and selecting one from them. But with this change, it will only list form the specified NS and select from one of them.

Testing:

Had 2 free hosts on different NS and one host free on the NS where the cluster is created, the controller assigned the host from specified NS to the cluster

```
Machine Ref:
    API Version:  infrastructure.cluster.x-k8s.io/v1beta1
    Kind:         ByoMachine
    Name:         aarya-xhq2w-zltl4
    Namespace:    sk-du-default-usertenant
    UID:          fade12ed-04d8-415b-adca-20a2f8cea8d2
```

[KAAP-562]: https://platform9.atlassian.net/browse/KAAP-562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR updates the ByoMachine controller's host selection logic by adding namespace filtering to ListOptions, ensuring hosts are only selected from the same namespace as the ByoMachine. This change addresses KAAP-562 and improves the precision and reliability of cluster provisioning.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>