### PR TITLE
kaap-560: Update the byoh controller validating webhook to allow deletion of byohost object when byoMachine does not exists in the cluster

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	mgr.GetWebhookServer().Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-byohost", &webhook.Admission{Handler: &infrastructurev1beta1.ByoHostValidator{}})
+	mgr.GetWebhookServer().Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-byohost", &webhook.Admission{Handler: &infrastructurev1beta1.ByoHostValidator{
+		Client: mgr.GetClient(),
+	}})
 
 	if err = (&byohcontrollers.BootstrapKubeconfigReconciler{
 		Client: mgr.GetClient(),


### PR DESCRIPTION
[KAAP-560](https://platform9.atlassian.net/issues/KAAP-560)

```
 ~/Documents  kubectl get byohosts -A                                                                                                                                                                    ✔  app-dataplane-1 󱃾  05:12:57 PM
NAMESPACE                                      NAME                    OSNAME   OSIMAGE              ARCH
sk-du-default-service                          kappi-sk-1-3            linux    Ubuntu 22.04.2 LTS   amd64
sk-du-default-service                          kappi-sk-1-4            linux    Ubuntu 22.04.2 LTS   amd64
sk-du-default-usertenant                       byoh-kaapi-test-2       linux    Ubuntu 22.04.2 LTS   amd64
sk-du-default-usertenant                       byoh-kaapi-test-3       linux    Ubuntu 22.04.2 LTS   amd64
test-du-kaapi-suite-3677930-default-service    test-kaapi-byoh-u22-1   linux    Ubuntu 22.04.2 LTS   amd64
test-du-kaapi-suite-3677930-default-service    test-kaapi-byoh-u22-2   linux    Ubuntu 22.04.2 LTS   amd64
test-du-smoke-3659325-default-westros          test-kaapi-byoh1-3      linux    Ubuntu 20.04.6 LTS   amd64
test-du-testbed-only-3669263-default-service   test-kaapi-byoh-u22-1   linux    Ubuntu 22.04.2 LTS   amd64
test-du-testbed-only-3670362-default-service   kaapi-test2             linux    Ubuntu 22.04.2 LTS   amd64
test-du-testbed-only-3670362-default-service   kaapi-test3             linux    Ubuntu 22.04.2 LTS   amd64
test-du-testbed-only-3670362-default-service   test-kaapi-byoh-u22-3   linux    Ubuntu 22.04.2 LTS   amd64
 ~/Documents  kubectl get byohost test-kaapi-byoh-u22-1 -n test-du-kaapi-suite-3677930-default-service -oyaml | yq '.status.machineRef'                                                                  ✔  app-dataplane-1 󱃾  05:13:05 PM
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ByoMachine
name: winter-kczvk-g24n6
namespace: test-du-kaapi-suite-3677930-default-service
uid: 4b33e96c-3350-4295-8275-8aa94c5d6655
 ~/Documents                                                                                                                                                                                                                 ✔  05:13:09 PM
 ~/Documents                                                                                                                                                                                                                 ✔  05:13:54 PM
 ~/Documents                                                                                                                                                                                                                 ✔  05:13:54 PM
 ~/Documents  kubectl delete byohost test-kaapi-byoh-u22-1 -n test-du-kaapi-suite-3677930-default-service                                                                                                ✔  app-dataplane-1 󱃾  05:13:54 PM
Error from server (cannot delete ByoHost when MachineRef is assigned): admission webhook "vbyohost.kb.io" denied the request: cannot delete ByoHost when MachineRef is assigned
 ~/Documents                                                                                                                                                                                                               1 ✘  05:15:38 PM
 ~/Documents  kubectl get byomachine winter-kczvk-g24n6 -n test-du-kaapi-suite-3677930-default-service                                                                                                 1 ✘  app-dataplane-1 󱃾  05:15:43 PM
Error from server (NotFound): byomachines.infrastructure.cluster.x-k8s.io "winter-kczvk-g24n6" not found
 ~/Documents                                                                                                                                                                                                               1 ✘  05:16:01 PM
 ~/Documents  # updating the image of byoh-controller                                                                                                                                                                      1 ✘  05:16:05 PM
 ~/Documents                                                                                                                                                                                                               1 ✘  05:16:21 PM
 ~/Documents                                                                                                                                                                                                               1 ✘  05:16:22 PM
 ~/Documents  kubectl edit pod byoh-controller-manager-788cbd4985-8qp9l -n kaapi                                                                                                                       1 ✘  app-dataplane-1 󱃾  05:16:22 PM
pod/byoh-controller-manager-788cbd4985-8qp9l edited
 ~/Documents                                                                                                                                                                                                            ✔  9s  05:16:54 PM
 ~/Documents                                                                                                                                                                                                                 ✔  05:17:04 PM
 ~/Documents                                                                                                                                                                                                                 ✔  05:17:04 PM
 ~/Documents  kubectl delete byohost test-kaapi-byoh-u22-1 -n test-du-kaapi-suite-3677930-default-service                                                                                                ✔  app-dataplane-1 󱃾  05:17:04 PM
byohost.infrastructure.cluster.x-k8s.io "test-kaapi-byoh-u22-1" deleted
 ~/Documents                                                                                                                                                                                                                 ✔  05:17:11 PM
 ~/Documents                                                                                                                                                                                                                 ✔  05:17:12 PM
 ~/Documents  kubectl get byohosts -A                                                                                                                                                                    ✔  app-dataplane-1 󱃾  05:17:12 PM
NAMESPACE                                      NAME                    OSNAME   OSIMAGE              ARCH
sk-du-default-service                          kappi-sk-1-3            linux    Ubuntu 22.04.2 LTS   amd64
sk-du-default-service                          kappi-sk-1-4            linux    Ubuntu 22.04.2 LTS   amd64
sk-du-default-usertenant                       byoh-kaapi-test-2       linux    Ubuntu 22.04.2 LTS   amd64
sk-du-default-usertenant                       byoh-kaapi-test-3       linux    Ubuntu 22.04.2 LTS   amd64
test-du-kaapi-suite-3677930-default-service    test-kaapi-byoh-u22-2   linux    Ubuntu 22.04.2 LTS   amd64
test-du-smoke-3659325-default-westros          test-kaapi-byoh1-3      linux    Ubuntu 20.04.6 LTS   amd64
test-du-testbed-only-3669263-default-service   test-kaapi-byoh-u22-1   linux    Ubuntu 22.04.2 LTS   amd64
test-du-testbed-only-3670362-default-service   kaapi-test2             linux    Ubuntu 22.04.2 LTS   amd64
test-du-testbed-only-3670362-default-service   kaapi-test3             linux    Ubuntu 22.04.2 LTS   amd64
test-du-testbed-only-3670362-default-service   test-kaapi-byoh-u22-3   linux    Ubuntu 22.04.2 LTS   amd64
 ~/Documents  kubectl get byomachine winter-kczvk-g24n6 -n test-du-kaapi-suite-3677930-default-service                                                                                                   ✔  app-dataplane-1 󱃾  05:17:19 PM
Error from server (NotFound): byomachines.infrastructure.cluster.x-k8s.io "winter-kczvk-g24n6" not found
```

[KAAP-560]: https://platform9.atlassian.net/browse/KAAP-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR enhances the ByoHost validating webhook by improving the deletion flow, adding context parameters to function signatures, and refining error handling to permit deletion when ByoMachine is not found. It also updates webhook registration in main.go for proper client dependency injection.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>