### PR TITLE
KAAP-657: Remove pf9 cluster label as a part of scaling down or byoh cluster deletion

### DIFF
--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -20,6 +20,8 @@ const (
 	AttachedByoMachineLabel = "byoh.infrastructure.cluster.x-k8s.io/byomachine-name"
 	// BundleLookupBaseRegistryAnnotation annotation used to store the base registry for the bundle lookup
 	BundleLookupBaseRegistryAnnotation = "byoh.infrastructure.cluster.x-k8s.io/bundle-registry"
+	// ClusterLabel label is used to mark a cluster where it is attached to
+	ClusterLabel = "kaapi.pf9.io/cluster-name"
 )
 
 // ByoHostSpec defines the desired state of ByoHost

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -602,12 +602,17 @@ func ByoHostToByoMachineMapFunc(gvk schema.GroupVersionKind) handler.MapFunc {
 }
 
 func (r *ByoMachineReconciler) markHostForCleanup(ctx context.Context, machineScope *byoMachineScope) error {
+	logger := log.FromContext(ctx).WithValues("cluster", machineScope.Cluster.Name)
 	helper, _ := patch.NewHelper(machineScope.ByoHost, r.Client)
 
 	if machineScope.ByoHost.Annotations == nil {
 		machineScope.ByoHost.Annotations = map[string]string{}
 	}
 	machineScope.ByoHost.Annotations[infrav1.HostCleanupAnnotation] = ""
+
+	// remove the pf9 cluster label
+	logger.Info("Removing pf9 cluster label %s from ByoHost %s", infrav1.ClusterLabel, machineScope.ByoHost.Name)
+	delete(machineScope.ByoHost.Labels, infrav1.ClusterLabel)
 
 	// Issue the patch for byohost
 	return helper.Patch(ctx, machineScope.ByoHost)


### PR DESCRIPTION
UI adds a label `kaapi.pf9.io/cluster-name` on the byohost object whenever it is selected or is a part of some cluster. 

Whenever cluster is deleted or that specific byohost is scaled down, the respective byomachine is deleted and byohost is cleaned up and ready to attach to other cluster. Removing `kaapi.pf9.io/cluster-name` as a part of this. 
 <div id='description'>
<h3>Summary by Bito</h3>
This PR updates the management of cluster labels for byohost objects by introducing a standardized cluster label constant and improving the cleanup process in the byomachine controller. These changes ensure proper removal of unwanted cluster labels during scaling down or deletion, enhancing overall cluster state management reliability.
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
</div>