### PR TITLE
 KAAP-714: Update byohctl to make onboarding of host region aware

### DIFF
--- a/cmd/byohctl/service/constants.go
+++ b/cmd/byohctl/service/constants.go
@@ -13,7 +13,7 @@ const (
 	DefaultFilePerms = 0644
 
 	// ByohAgentDebPackageURL is the URL to download the agent package
-	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.78"
+	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.160"
 	// ByohAgentDebPackageFilename is the filename of the agent package
 	ByohAgentDebPackageFilename = "pf9-byohost-agent.deb"
 	// ByohAgentServiceName is the name of the agent service
@@ -35,6 +35,9 @@ const (
 
 	// Systemctl constants
 	Systemctl = "systemctl"
+
+	// pcd-kaapi region key
+	PcdKaapiRegionKey = "pcd-kaapi.pf9.io/region"
 )
 
 var (

--- a/scripts/pf9-byohost-agent-after-install.sh
+++ b/scripts/pf9-byohost-agent-after-install.sh
@@ -25,9 +25,11 @@ if [ -f /lib/systemd/system/pf9-byohost-agent.service ]; then
 mkdir -p /etc/pf9-byohost-agent.service.d/
 touch /etc/pf9-byohost-agent.service.d/pf9-byohost-agent.conf
 export NAMESPACE=$(grep 'namespace: *' /root/.byoh/config | awk '{print $2}')
+export REGION=$(cat /root/.byoh/region)
 
 echo "NAMESPACE=$NAMESPACE" > /etc/pf9-byohost-agent.service.d/pf9-byohost-agent.conf
 echo "BOOTSTRAP_KUBECONFIG=/etc/pf9-byohost-agent.service.d/bootstrap-kubeconfig.yaml" >> /etc/pf9-byohost-agent.service.d/pf9-byohost-agent.conf 
+echo "REGION=$REGION" >> /etc/pf9-byohost-agent.service.d/pf9-byohost-agent.conf 
 
 systemctl daemon-reload
 systemctl enable pf9-byohost-agent.service

--- a/service/pf9-byohostagent.service
+++ b/service/pf9-byohostagent.service
@@ -9,8 +9,8 @@ StartLimitBurst=2
 Type=simple
 RestartSec=5s
 Restart=always
-EnvironmentFile=/etc/pf9-byohost-agent.service.d/pf9-byohost-agent.conf 
-ExecStart=/bin/bash -c "/binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig \"$BOOTSTRAP_KUBECONFIG\" --namespace \"$NAMESPACE\" >> /var/log/pf9/byoh/byoh-agent.log 2>&1"
+EnvironmentFile=/etc/pf9-byohost-agent.service.d/pf9-byohost-agent.conf
+ExecStart=/bin/bash -c "/binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig \"$BOOTSTRAP_KUBECONFIG\" --namespace \"$NAMESPACE\" --label \"$REGION\" >> /var/log/pf9/byoh/byoh-agent.log 2>&1"
 User=root
 Group=root
 [Install]


### PR DESCRIPTION
```
root@ip-172-31-2-46:~# ./byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe -t service -p s0upnaz1 -r regionone
[2025-06-04 18:01:05] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-06-04 18:01:06] [SUCCESS] Successfully obtained authentication token
[2025-06-04 18:01:06] [SUCCESS] Successfully retrieved secret
[2025-06-04 18:01:06] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-06-04 18:01:07] [SUCCESS] All required packages installed successfully
[2025-06-04 18:01:09] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-04 18:01:10] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-04 18:01:10] [SUCCESS] Agent setup completed successfully
[2025-06-04 18:01:10] [SUCCESS] Successfully onboarded the host
[2025-06-04 18:01:10] [SUCCESS] BYOH Agent Service logs are available at:
[2025-06-04 18:01:10] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-06-04 18:01:10] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service
```

```
root@ip-172-31-2-46:~# ./byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe -t service -p s0upnaz1 -r Infra
[2025-06-04 18:00:31] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-06-04 18:00:33] [SUCCESS] Successfully obtained authentication token
[2025-06-04 18:00:33] [SUCCESS] Successfully retrieved secret
[2025-06-04 18:00:33] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-06-04 18:00:35] [SUCCESS] All required packages installed successfully
[2025-06-04 18:00:38] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-04 18:00:39] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-04 18:00:39] [SUCCESS] Agent setup completed successfully
[2025-06-04 18:00:39] [SUCCESS] Successfully onboarded the host
[2025-06-04 18:00:39] [SUCCESS] BYOH Agent Service logs are available at:
[2025-06-04 18:00:39] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-06-04 18:00:39] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service
```

```
root@ip-172-31-2-46:~# ./byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe -t service -p s0upnaz1 -r invalidregionname
[2025-06-04 17:59:50] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-06-04 17:59:51] [SUCCESS] Successfully obtained authentication token
[2025-06-04 17:59:51] [SUCCESS] Successfully retrieved secret
[2025-06-04 17:59:51] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-06-04 17:59:51] [ERROR] Region invalidregionname is not available for the tenant, rolling back onboarding process
[2025-06-04 17:59:51] [SUCCESS] Successfully deleted saved kubeconfig from /root/.byoh/config
```


<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the byohctl tool with region awareness by adding a region parameter across client code, onboarding commands, and service configuration. It implements validations for region availability and adds rollback procedures when needed, improving the reliability and flexibility of host onboarding with region-specific logic.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 3
-->
</div>