### PR TITLE
BYOH agent service upgrades

### DIFF
--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -6,143 +6,45 @@ BUNDLE_DOWNLOAD_PATH={{.BundleDownloadPath}}
 BUNDLE_ADDR={{.BundleAddrs}}
 IMGPKG_VERSION={{.ImgpkgVersion}}
 ARCH={{.Arch}}
-BUNDLE_PATH=$BUNDLE_DOWNLOAD_PATH/$BUNDLE_ADDR
-
-# Logging setup
-LOG_FILE="/var/log/pf9/agent-upgrade-$(date +%Y%m%d-%H%M%S).log"
-LOG_DIR=$(dirname "$LOG_FILE")
-mkdir -p "$LOG_DIR"
-
-exec > >(tee -a "$LOG_FILE") 2>&1
-
-echo "=== Starting installation/upgrade at $(date) ==="
-
-# Lock file to prevent concurrent execution
+BUNDLE_PATH="$BUNDLE_DOWNLOAD_PATH/$BUNDLE_ADDR"
 LOCK_FILE="/var/run/pf9-agent-upgrade.lock"
+UPGRADE_MARKER="$HOME/.byoh/upgrade_complete"
+AGENT_SERVICE="pf9-byohost-agent"
 
-try_cleanup() {
+# Logging helper
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+cleanup() {
     local exit_code=$?
-    echo "=== Cleanup started with exit code: $exit_code ==="
+    log "Cleanup started with exit code: $exit_code"
     
-    # Release the lock
-    if [ -f "$LOCK_FILE" ]; then
-        flock -u 200
-        rm -f "$LOCK_FILE"
+    # Release the lock if held
+    { flock -u 200; } 2>/dev/null || true
+    rm -f "$LOCK_FILE" 2>/dev/null || true
+    
+    # Clean up temporary files
+    if [ -n "${AGENT_TEMP_DIR:-}" ] && [ -d "$AGENT_TEMP_DIR" ]; then
+        rm -rf "$AGENT_TEMP_DIR"
+        log "Removed temporary directory: $AGENT_TEMP_DIR"
     fi
     
-    echo "=== Cleanup completed at $(date) ==="
+    log "Cleanup completed"
     exit $exit_code
 }
 
-# Setup trap for cleanup
-trap try_cleanup EXIT INT TERM
+trap cleanup EXIT INT TERM
 
-# Try to acquire lock
+# Acquire lock
 exec 200>"$LOCK_FILE"
 if ! flock -n 200; then
-    echo "Error: Another instance is already running. Exiting." >&2
+    log "Another installation is in progress. Exiting." >&2
     exit 1
 fi
 
-echo "=== Acquired lock, proceeding with installation/upgrade ==="
+log "Starting installation/upgrade"
 
-# --- BYOH Agent self-upgrade logic ---
-upgrade_agent_if_needed() {
-    local start_time=$(date +%s)
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting agent upgrade check"
-    
-    if ! command -v imgpkg >/dev/null; then
-        echo "[WARN] imgpkg not available, skipping agent upgrade check"
-        return 0
-    fi
-
-    local agent_temp_dir
-    agent_temp_dir=$(mktemp -d)
-    echo "[INFO] Using temporary directory: $agent_temp_dir"
-    
-    # Enhanced cleanup function
-    cleanup() {
-        local cleanup_start=$(date +%s)
-        echo "[INFO] Starting cleanup of temporary files"
-        
-        if [ -d "$agent_temp_dir" ]; then
-            rm -rf "$agent_temp_dir"
-            echo "[INFO] Removed temporary directory: $agent_temp_dir"
-        fi
-        
-        local cleanup_duration=$(( $(date +%s) - cleanup_start ))
-        echo "[INFO] Cleanup completed in ${cleanup_duration}s"
-    }
-    trap cleanup EXIT
-
-    # Pull latest agent
-    echo "[INFO] Downloading latest agent package..."
-    if ! imgpkg pull -i "quay.io/jayanthtjvrr/byoh-agent-deb:latest" -o "$agent_temp_dir"; then
-        echo "[ERROR] Failed to pull agent image"
-        return 1
-    fi
-
-    # Find the deb package
-    local latest_deb
-    latest_deb=$(find "$agent_temp_dir" -name "pf9-byohost-agent*.deb" | head -1)
-    if [ -z "$latest_deb" ]; then
-        echo "[ERROR] Could not find agent package in the downloaded image"
-        return 1
-    fi
-
-    # Get package version for logging
-    local pkg_ver
-    pkg_ver=$(dpkg-deb -f "$latest_deb" Version)
-    echo "[INFO] Installing agent package version: $pkg_ver"
-    
-    # Install the package
-    if ! dpkg -i "$latest_deb"; then
-        echo "[ERROR] Failed to install agent package $pkg_ver"
-        return 1
-    fi
-    
-    echo "[INFO] Agent package installed, restarting service..."
-        
-        # Reload systemd and restart service with retry logic
-        systemctl daemon-reload
-        
-        local max_retries=3
-        local retry_delay=5
-        local attempt=1
-        
-        while [ $attempt -le $max_retries ]; do
-            echo "[INFO] Restart attempt $attempt of $max_retries..."
-            
-            if systemctl restart pf9-byohost-agent; then
-                # Verify service is running
-                if systemctl is-active --quiet pf9-byohost-agent; then
-                    echo "[INFO] Agent service restarted successfully"
-                    break
-                fi
-            fi
-            
-            if [ $attempt -eq $max_retries ]; then
-                echo "[ERROR] Failed to restart agent service after $max_retries attempts"
-                return 1
-            fi
-            
-            echo "[WARN] Service restart failed, retrying in ${retry_delay}s..."
-            sleep $retry_delay
-            attempt=$((attempt + 1))
-        done
-        
-        # Final verification
-        if systemctl is-active --quiet pf9-byohost-agent; then
-            local end_time=$(date +%s)
-            local duration=$((end_time - start_time))
-            echo "[SUCCESS] Agent upgraded to $latest_ver in ${duration}s"
-            return 0
-        else
-            echo "[ERROR] Agent service is not running after upgrade"
-            return 1
-        fi
-}
-# --- End BYOH Agent self-upgrade logic ---
 
 if ! command -v imgpkg >>/dev/null; then
     echo "[INFO] Installing imgpkg"	
@@ -164,10 +66,192 @@ if ! command -v imgpkg >>/dev/null; then
     echo "[INFO] imgpkg installation complete"
 fi
 
-# Run agent upgrade after imgpkg is available
-echo "[INFO] Starting agent upgrade process"
-if ! upgrade_agent_if_needed; then
-    echo "[WARN] Agent upgrade encountered issues, but continuing with installation"
+# --- BYOH Agent self-upgrade logic ---
+upgrade_agent_if_needed() {
+    local start_time=$(date +%s)
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting agent upgrade check"
+    
+    # Check if agent service is installed and enabled
+    if ! systemctl is-enabled pf9-byohost-agent >/dev/null 2>&1; then
+        echo "[INFO] Agent service not found or not enabled, skipping upgrade"
+        return 0
+    fi
+    
+    if ! command -v imgpkg >/dev/null; then
+        echo "[WARN] imgpkg not available, skipping agent upgrade check"
+        return 0
+    fi
+
+    # Create a temporary directory for the agent files
+    AGENT_TEMP_DIR=$(mktemp -d)
+    echo "[INFO] Using temporary directory: $AGENT_TEMP_DIR"
+    
+    # Cleanup function for this scope
+    cleanup() {
+        local exit_code=$?
+        echo "[INFO] Starting cleanup of temporary files"
+        if [ -n "$AGENT_TEMP_DIR" ] && [ -d "$AGENT_TEMP_DIR" ]; then
+            rm -rf "$AGENT_TEMP_DIR"
+            echo "[INFO] Removed temporary directory: $AGENT_TEMP_DIR"
+            AGENT_TEMP_DIR=""
+        fi
+        exit $exit_code
+    }
+    trap cleanup EXIT
+
+    # Download the latest agent package
+    echo "[INFO] Downloading latest agent package..."
+    if ! imgpkg pull -i "quay.io/jayanthtjvrr/byoh-agent-deb:latest" -o "$AGENT_TEMP_DIR"; then
+        echo "[ERROR] Failed to download agent package"
+        return 1
+    fi
+
+    # Find the .deb file
+    local latest_deb
+    latest_deb=$(find "$AGENT_TEMP_DIR" -name "pf9-byohost-agent*.deb" | head -1)
+    if [ -z "$latest_deb" ]; then
+        echo "[ERROR] Could not find agent package in the downloaded image"
+        return 1
+    fi
+
+    # Get package version for logging
+    local pkg_ver
+    pkg_ver=$(dpkg-deb -f "$latest_deb" Version)
+    echo "[INFO] Installing agent package version: $pkg_ver"
+    
+    # Create a temporary script to handle the upgrade
+    local upgrade_script
+    upgrade_script=$(mktemp)
+    
+    # Create the upgrade script with minimal changes
+    {
+    echo '#!/bin/bash'
+    echo 'set -e  # Exit on error'
+    echo 'log() { echo "[$(date "+%Y-%m-%d %H:%M:%S")] [UPGRADE] $1" >&2; }'
+    echo 'log "=== Starting agent upgrade process ==="'
+    echo ''
+    echo '# Set up paths'
+    echo 'CONFIG_DIR="/root/.byoh"'
+    echo ''
+    echo 'log "Starting agent upgrade"'
+    echo 'echo "Hostname: $(hostname)"'
+    echo 'echo "Current user: $(whoami)"'
+    echo 'echo "Home directory: $HOME"'
+    echo ''
+    echo '# Backup existing config and extract namespace'
+    echo 'if [ -d "$CONFIG_DIR" ]; then'
+    echo '  log "Backing up existing configuration..."'
+    echo '  BACKUP_DIR="/tmp/byoh-config-backup-$(date +%s)"'
+    echo '  mkdir -p "$BACKUP_DIR"'
+    echo '  cp -a "$CONFIG_DIR" "$BACKUP_DIR/" 2>/dev/null || true'
+    echo '  log "Configuration backed up to $BACKUP_DIR"'
+    echo 'fi'
+    echo ''
+    echo '# Perform clean reinstall'
+    echo 'log "Performing clean reinstall..."'
+    echo 'DEB_FILE="$1"'
+    echo 'if [ ! -f "$DEB_FILE" ]; then'
+    echo '  log "Error: DEB file not found: $DEB_FILE"'
+    echo '  exit 1'
+    echo 'fi'
+    echo ''
+    echo '# Stop and remove existing package'
+    echo 'log "Stopping and removing existing package..."'
+    echo 'systemctl stop pf9-byohost-agent 2>/dev/null || true'
+    echo 'dpkg --purge --force-confold pf9-byohost-agent 2>/dev/null || true'
+    echo ''
+    echo '# Restore .byoh directory'
+    echo 'if [ -n "$BACKUP_DIR" ] && [ -d "$BACKUP_DIR/.byoh" ]; then'
+    echo '  log "Restoring .byoh directory..."'
+    echo '  mkdir -p "$CONFIG_DIR" 2>/dev/null || true'
+    echo '  cp -a "$BACKUP_DIR/.byoh/"* "$CONFIG_DIR/" 2>/dev/null || true'
+    echo '  chmod 700 "$CONFIG_DIR" 2>/dev/null || true'
+    echo '  chmod 600 "$CONFIG_DIR/"* 2>/dev/null || true'
+    echo 'fi'
+    echo ''
+    echo '# Install the new package'
+    echo 'log "Installing new package..."'
+    echo 'if ! dpkg -i --force-confold "$DEB_FILE"; then'
+    echo '  log "Fixing broken dependencies..."'
+    echo '  apt-get update && apt-get -f install -y || true'
+    echo 'fi'
+    echo ''
+    echo '# Clean up'
+    echo 'rm -f "$1" 2>/dev/null || true'
+    echo 'rm -rf "$BACKUP_DIR" 2>/dev/null || true'
+    echo ''
+    echo 'log "Agent upgrade completed"'
+    echo '# Create upgrade marker to prevent re-running'
+    echo 'UPGRADE_MARKER="$HOME/.byoh/upgrade_complete"'
+    echo 'mkdir -p "$(dirname "$UPGRADE_MARKER")" 2>/dev/null || true'
+    echo 'touch "$UPGRADE_MARKER"'
+    echo 'log "Created upgrade marker: $UPGRADE_MARKER"'
+    echo 'log "See $LOG_FILE for details"'
+    echo 'exit 0'
+    } > "$upgrade_script"
+
+    # Make the script executable
+    chmod +x "$upgrade_script"
+    
+    echo "[DEBUG] Starting upgrade process in the foreground..."
+    echo "[DEBUG] Upgrade script path: $upgrade_script"
+    echo "[DEBUG] DEB file: $latest_deb"
+    
+    # Set up log file
+    LOG_FILE="/var/log/pf9/agent-upgrade-$(date +%Y%m%d-%H%M%S).log"
+    mkdir -p "$(dirname "$LOG_FILE")"
+    touch "$LOG_FILE"
+    
+    # Create a systemd service to run the upgrade independently
+    SERVICE_NAME="pf9-agent-upgrade-$(date +%s).service"
+    
+    # Create the service file with proper escaping
+    {
+    echo '[Unit]'
+    echo 'Description=PF9 Agent Upgrade'
+    echo 'After=network.target'
+    echo ''
+    echo '[Service]'
+    echo 'Type=oneshot'
+    echo 'Environment=DEBIAN_FRONTEND=noninteractive'
+    echo 'EnvironmentFile=-/etc/environment'
+    echo "Environment=HOME=/root"
+    echo "ExecStart=/bin/bash -c 'export HOME=/root; $upgrade_script \"$latest_deb\"'"
+    echo "StandardOutput=append:${LOG_FILE}"
+    echo ''
+    echo '[Install]'
+    echo 'WantedBy=multi-user.target'
+    } > "/etc/systemd/system/${SERVICE_NAME}"
+
+    # Reload systemd and start the service
+    systemctl daemon-reload
+    systemctl start "${SERVICE_NAME}"
+    
+    echo "[INFO] Upgrade process started as systemd service: ${SERVICE_NAME}"
+    echo "[INFO] Logs: $LOG_FILE"
+    
+    # Clean up the service file after a delay
+    (
+        sleep 300  # Wait 5 minutes for upgrade to complete
+        systemctl stop "${SERVICE_NAME}" 2>/dev/null || true
+        systemctl disable "${SERVICE_NAME}" 2>/dev/null || true
+        rm -f "/etc/systemd/system/${SERVICE_NAME}"
+        systemctl daemon-reload
+        rm -f "$upgrade_script"
+    ) &
+    
+    # Return success immediately since we're running in background
+    return 0
+}
+# --- End BYOH Agent self-upgrade logic ---
+
+
+# Check if upgrade is needed (upgrade marker not present)
+if [ -f "$UPGRADE_MARKER" ]; then
+    log "Upgrade already completed, skipping upgrade check"
+else
+    log "Checking for agent upgrade..."
+    upgrade_agent_if_needed || log "Agent upgrade encountered issues, continuing with installation"
 fi
 
 echo "[INFO] Proceeding with bundle download"
@@ -193,7 +277,7 @@ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm; do
     dpkg --install "$BUNDLE_PATH/$pkg.deb" && apt-mark hold $pkg
 done
 
-## intalling containerd
+## installing containerd
 tar -C / -xvf "$BUNDLE_PATH/containerd.tar"
 mkdir -p /etc/containerd
 containerd config default > /etc/containerd/config.toml
@@ -204,3 +288,9 @@ systemctl daemon-reload && systemctl enable containerd && systemctl start contai
 
 echo "[SUCCESS] Installation complete!"
 echo "=== Installation completed at $(date) ==="
+
+# Clean up upgrade marker if it exists
+if [ -f "$UPGRADE_MARKER" ]; then
+    echo "[INFO] Cleaning up upgrade marker"
+    rm -f "$UPGRADE_MARKER"
+fi

--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -1,30 +1,194 @@
-set -euox pipefail
+#!/bin/bash
+set -euo pipefail
 
+# Configuration
 BUNDLE_DOWNLOAD_PATH={{.BundleDownloadPath}}
 BUNDLE_ADDR={{.BundleAddrs}}
 IMGPKG_VERSION={{.ImgpkgVersion}}
 ARCH={{.Arch}}
 BUNDLE_PATH=$BUNDLE_DOWNLOAD_PATH/$BUNDLE_ADDR
 
+# Logging setup
+LOG_FILE="/var/log/pf9/agent-upgrade-$(date +%Y%m%d-%H%M%S).log"
+LOG_DIR=$(dirname "$LOG_FILE")
+mkdir -p "$LOG_DIR"
+
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "=== Starting installation/upgrade at $(date) ==="
+
+# Lock file to prevent concurrent execution
+LOCK_FILE="/var/run/pf9-agent-upgrade.lock"
+
+try_cleanup() {
+    local exit_code=$?
+    echo "=== Cleanup started with exit code: $exit_code ==="
+    
+    # Release the lock
+    if [ -f "$LOCK_FILE" ]; then
+        flock -u 200
+        rm -f "$LOCK_FILE"
+    fi
+    
+    echo "=== Cleanup completed at $(date) ==="
+    exit $exit_code
+}
+
+# Setup trap for cleanup
+trap try_cleanup EXIT INT TERM
+
+# Try to acquire lock
+exec 200>"$LOCK_FILE"
+if ! flock -n 200; then
+    echo "Error: Another instance is already running. Exiting." >&2
+    exit 1
+fi
+
+echo "=== Acquired lock, proceeding with installation/upgrade ==="
+
+# --- BYOH Agent self-upgrade logic ---
+upgrade_agent_if_needed() {
+    local start_time=$(date +%s)
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting agent upgrade check"
+    
+    if ! command -v imgpkg >/dev/null; then
+        echo "[WARN] imgpkg not available, skipping agent upgrade check"
+        return 0
+    fi
+
+    local agent_temp_dir
+    agent_temp_dir=$(mktemp -d)
+    echo "[INFO] Using temporary directory: $agent_temp_dir"
+    
+    # Enhanced cleanup function
+    cleanup() {
+        local cleanup_start=$(date +%s)
+        echo "[INFO] Starting cleanup of temporary files"
+        
+        if [ -d "$agent_temp_dir" ]; then
+            rm -rf "$agent_temp_dir"
+            echo "[INFO] Removed temporary directory: $agent_temp_dir"
+        fi
+        
+        local cleanup_duration=$(( $(date +%s) - cleanup_start ))
+        echo "[INFO] Cleanup completed in ${cleanup_duration}s"
+    }
+    trap cleanup EXIT
+
+    # Get current version
+    local current_ver
+    current_ver=$(dpkg-query --showformat='${Version}' --show pf9-byohost-agent 2>/dev/null || echo "0.0.0")
+    echo "[INFO] Current agent version: $current_ver"
+
+    # Pull latest agent
+    echo "[INFO] Checking for latest agent version..."
+    if ! imgpkg pull -i "quay.io/platform9/byoh-agent-deb:latest" -o "$agent_temp_dir"; then
+        echo "[WARN] Failed to pull agent image, continuing with existing version"
+        return 1
+    fi
+
+    # Find the deb package
+    local latest_deb
+    latest_deb=$(find "$agent_temp_dir" -name "pf9-byohost-agent*.deb" | head -1)
+    if [ -z "$latest_deb" ]; then
+        echo "[WARN] Could not find agent package in the downloaded image"
+        return 1
+    fi
+
+    # Get latest version
+    local latest_ver
+    latest_ver=$(dpkg-deb -f "$latest_deb" Version)
+    echo "[INFO] Latest available version: $latest_ver"
+    
+    # Compare versions
+    if dpkg --compare-versions "$latest_ver" gt "$current_ver" 2>/dev/null; then
+        echo "[INFO] Upgrading agent from $current_ver to $latest_ver"
+        
+        # Install the new version
+        if ! dpkg -i "$latest_deb"; then
+            echo "[ERROR] Failed to install agent package $latest_ver"
+            return 1
+        fi
+        
+        echo "[INFO] Agent package installed, restarting service..."
+        
+        # Reload systemd and restart service with retry logic
+        systemctl daemon-reload
+        
+        local max_retries=3
+        local retry_delay=5
+        local attempt=1
+        
+        while [ $attempt -le $max_retries ]; do
+            echo "[INFO] Restart attempt $attempt of $max_retries..."
+            
+            if systemctl restart pf9-byohost-agent; then
+                # Verify service is running
+                if systemctl is-active --quiet pf9-byohost-agent; then
+                    echo "[INFO] Agent service restarted successfully"
+                    break
+                fi
+            fi
+            
+            if [ $attempt -eq $max_retries ]; then
+                echo "[ERROR] Failed to restart agent service after $max_retries attempts"
+                return 1
+            fi
+            
+            echo "[WARN] Service restart failed, retrying in ${retry_delay}s..."
+            sleep $retry_delay
+            attempt=$((attempt + 1))
+        done
+        
+        # Final verification
+        if systemctl is-active --quiet pf9-byohost-agent; then
+            local end_time=$(date +%s)
+            local duration=$((end_time - start_time))
+            echo "[SUCCESS] Agent upgraded to $latest_ver in ${duration}s"
+            return 0
+        else
+            echo "[ERROR] Agent service is not running after upgrade"
+            return 1
+        fi
+    else
+        echo "[INFO] Agent is already at the latest version ($current_ver)"
+    fi
+    
+    cleanup
+    
+    local end_time=$(date +%s)
+    local duration=$((end_time - start_time))
+    echo "[INFO] Agent upgrade check completed in ${duration}s"
+}
+# --- End BYOH Agent self-upgrade logic ---
+
 if ! command -v imgpkg >>/dev/null; then
-    echo "installing imgpkg"	
+    echo "[INFO] Installing imgpkg"	
     
     if command -v wget >>/dev/null; then
         dl_bin="wget -nv -O-"
     elif command -v curl >>/dev/null; then
         dl_bin="curl -s -L"
     else
-        echo "installing curl"
-        apt-get install -y curl
+        echo "[INFO] Installing curl"
+        apt-get update && apt-get install -y curl
         dl_bin="curl -s -L"
     fi
     
-    $dl_bin github.com/vmware-tanzu/carvel-imgpkg/releases/download/$IMGPKG_VERSION/imgpkg-linux-$ARCH > /tmp/imgpkg
+    echo "[INFO] Downloading imgpkg..."
+    $dl_bin https://github.com/vmware-tanzu/carvel-imgpkg/releases/download/$IMGPKG_VERSION/imgpkg-linux-$ARCH > /tmp/imgpkg
     mv /tmp/imgpkg /usr/local/bin/imgpkg
     chmod +x /usr/local/bin/imgpkg
+    echo "[INFO] imgpkg installation complete"
 fi
 
-echo "downloading bundle"
+# Run agent upgrade after imgpkg is available
+echo "[INFO] Starting agent upgrade process"
+if ! upgrade_agent_if_needed; then
+    echo "[WARN] Agent upgrade encountered issues, but continuing with installation"
+fi
+
+echo "[INFO] Proceeding with bundle download"
 mkdir -p $BUNDLE_PATH
 imgpkg pull -i $BUNDLE_ADDR -o $BUNDLE_PATH
 
@@ -56,4 +220,5 @@ containerd config default > /etc/containerd/config.toml
 ## starting containerd service
 systemctl daemon-reload && systemctl enable containerd && systemctl start containerd
 
-echo "Installation complete!"
+echo "[SUCCESS] Installation complete!"
+echo "=== Installation completed at $(date) ==="

--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -75,15 +75,10 @@ upgrade_agent_if_needed() {
     }
     trap cleanup EXIT
 
-    # Get current version
-    local current_ver
-    current_ver=$(dpkg-query --showformat='${Version}' --show pf9-byohost-agent 2>/dev/null || echo "0.0.0")
-    echo "[INFO] Current agent version: $current_ver"
-
     # Pull latest agent
-    echo "[INFO] Checking for latest agent version..."
-    if ! imgpkg pull -i "quay.io/platform9/byoh-agent-deb:latest" -o "$agent_temp_dir"; then
-        echo "[WARN] Failed to pull agent image, continuing with existing version"
+    echo "[INFO] Downloading latest agent package..."
+    if ! imgpkg pull -i "quay.io/jayanthtjvrr/byoh-agent-deb:latest" -o "$agent_temp_dir"; then
+        echo "[ERROR] Failed to pull agent image"
         return 1
     fi
 
@@ -91,26 +86,22 @@ upgrade_agent_if_needed() {
     local latest_deb
     latest_deb=$(find "$agent_temp_dir" -name "pf9-byohost-agent*.deb" | head -1)
     if [ -z "$latest_deb" ]; then
-        echo "[WARN] Could not find agent package in the downloaded image"
+        echo "[ERROR] Could not find agent package in the downloaded image"
         return 1
     fi
 
-    # Get latest version
-    local latest_ver
-    latest_ver=$(dpkg-deb -f "$latest_deb" Version)
-    echo "[INFO] Latest available version: $latest_ver"
+    # Get package version for logging
+    local pkg_ver
+    pkg_ver=$(dpkg-deb -f "$latest_deb" Version)
+    echo "[INFO] Installing agent package version: $pkg_ver"
     
-    # Compare versions
-    if dpkg --compare-versions "$latest_ver" gt "$current_ver" 2>/dev/null; then
-        echo "[INFO] Upgrading agent from $current_ver to $latest_ver"
-        
-        # Install the new version
-        if ! dpkg -i "$latest_deb"; then
-            echo "[ERROR] Failed to install agent package $latest_ver"
-            return 1
-        fi
-        
-        echo "[INFO] Agent package installed, restarting service..."
+    # Install the package
+    if ! dpkg -i "$latest_deb"; then
+        echo "[ERROR] Failed to install agent package $pkg_ver"
+        return 1
+    fi
+    
+    echo "[INFO] Agent package installed, restarting service..."
         
         # Reload systemd and restart service with retry logic
         systemctl daemon-reload
@@ -150,15 +141,6 @@ upgrade_agent_if_needed() {
             echo "[ERROR] Agent service is not running after upgrade"
             return 1
         fi
-    else
-        echo "[INFO] Agent is already at the latest version ($current_ver)"
-    fi
-    
-    cleanup
-    
-    local end_time=$(date +%s)
-    local duration=$((end_time - start_time))
-    echo "[INFO] Agent upgrade check completed in ${duration}s"
 }
 # --- End BYOH Agent self-upgrade logic ---
 


### PR DESCRIPTION
This resolves [KAAP-634](https://platform9.atlassian.net/browse/KAAP-634)

This PR adds the pf9-byohost-agent service upgrade feature. So, we have a install.sh file which runs on the node everytime there is a change in the cluster MD. We were using this feature for BYOH cluster upgrades as well. Now, we added a logic to create a systemd service for agent service upgrade from the install.sh file itself. So, the process is:

1. A change in MD, invokes the install.sh on node.
2. We pull the latest deb file and invoke the systemd service for agent upgrade.
3. Download required k8s bundle. (previous install.sh file flow)
4. install the k8s bundle and join the cluster. (previous install.sh file flow)

systemd service for agent upgrade logic:

We have a UPGRADE_MARKER file in ~/.byoh/, this file is created when the upgrade happens for the first time.

So, the flow is, the upgrade service gets called which will run independent of the BYOH agent service and logs in `/var/log/pf9/agent-upgrade-*.log`. This upgrade service, takes the back up of `~/.byoh/config` stops the BYOH agent service restores `~/.byoh/config` and installs the new bundle and create the UPGRADE_MARKER file and then checks if the BYOH agent service has come up running or not.

Once, this upgrade service is successfully ran, the BYOH agent service restarts with the new bundle. In this iteration, the upgrade service doesn't get invoked because we are invoking the upgrade service only if the UPGRADE_MARKER is not present, if it is present, we continue only with the installation.

Testing: 

Invoking the upgrade service in the foreground
```
I0610 18:40:16.652929  338453 host_reconciler.go:169]  "msg"="executing install script" "ByoHost"={"name":"jayanth-byo-upg-2","namespace":"byo-upg-3-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="jayanth-byo-upg-2" "namespace"="byo-upg-3-default-service" "reconcileID"="61957579-d479-4667-b905-24beee28c25f"
[2025-06-10 18:40:16] Starting installation/upgrade
[2025-06-10 18:40:16] Agent upgrade check...
[2025-06-10 18:40:16] Starting agent upgrade check
[INFO] Using temporary directory: /tmp/tmp.jnyftVF6e9
[INFO] Downloading latest agent package...
[INFO] Installing agent package version: 1.0
[DEBUG] Starting upgrade process in the foreground...
[DEBUG] Upgrade script path: /tmp/tmp.IgzTdx9cTP
[DEBUG] DEB file: /tmp/tmp.jnyftVF6e9/pf9-byohost-agent.deb
I0610 18:40:18.787410  338453 internal.go:581]  "msg"="Stopping and waiting for non leader election runnables" 
I0610 18:40:18.787475  338453 internal.go:585]  "msg"="Stopping and waiting for leader election runnables" 
I0610 18:40:18.787707  338453 controller.go:248]  "msg"="Shutdown signal received, waiting for all workers to finish" "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost"
```


Upgrade service logs : 
```
[2025-06-10 18:40:18] [UPGRADE] === Starting agent upgrade process ===
[2025-06-10 18:40:18] [UPGRADE] Starting agent upgrade
Hostname: jayanth-byo-upg-2
Current user: root
Home directory: /root
[2025-06-10 18:40:18] [UPGRADE] Backing up existing configuration...
[2025-06-10 18:40:18] [UPGRADE] Configuration backed up to /tmp/byoh-config-backup-1749580818
[2025-06-10 18:40:18] [UPGRADE] Performing clean reinstall...
[2025-06-10 18:40:18] [UPGRADE] Stopping and removing existing package...
(Reading database ... 64089 files and directories currently installed.)
Removing pf9-byohost-agent (1.0) ...
Starting uninstallation of pf9-byoh-hostagent...
WARNING: pf9-byoh-hostagent could not be stopped before uninstallation
Stopping and disabling pf9-byoh-hostagent service...
Service stopped successfully
Systemd daemon reloaded
Removing binary...
Binary removed successfully
Removing service file...
Service file removed successfully
Removing log files...
Log files removed successfully
Conf files already removed or not found 
Removing Config File
Config file removed successfully
Removing packages directory...
packages dir removed successfully
Removing .byoh directory...
.byoh dir removed successfully
 | not removed dependencies              |
 | socat conntrack ebtables and ethtools |
 | remove it according to your need      |
byohctl already removed or not found
Uninstallation of pf9-byoh-hostagent completed successfully
Post removal script of pf9-BYOHOST-agent package
Purging configuration files for pf9-byohost-agent (1.0) ...
Post removal script of pf9-BYOHOST-agent package
[2025-06-10 18:40:19] [UPGRADE] Restoring .byoh directory...
[2025-06-10 18:40:19] [UPGRADE] Installing new package...
Selecting previously unselected package pf9-byohost-agent.
(Reading database ... 64084 files and directories currently installed.)
Preparing to unpack .../pf9-byohost-agent.deb ...
Unpacking pf9-byohost-agent (1.0) ...
Setting up pf9-byohost-agent (1.0) ...
after pf9-byohost-agent installation
Created symlink /etc/systemd/system/multi-user.target.wants/pf9-byohost-agent.service → /etc/systemd/system/pf9-byohost-agent.service.
[2025-06-10 18:40:20] [UPGRADE] Agent upgrade completed
[2025-06-10 18:40:20] [UPGRADE] Created upgrade marker: /root/.byoh/upgrade_complete
[2025-06-10 18:40:20] [UPGRADE] See  for details
```

Once, the upgrade is done, the installation script is continued in the next call
```
I0610 19:13:13.432656  340876 host_reconciler.go:169]  "msg"="executing install script" "ByoHost"={"name":"jayanth-byo-upg-2","namespace":"byo-upg-3-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="jayanth-byo-upg-2" "namespace"="byo-upg-3-default-service" "reconcileID"="3f9f494d-d5b6-4368-8739-64f055e7f7d1"
[2025-06-10 19:13:13] Starting installation/upgrade
[INFO] Proceeding with bundle download
Firewall stopped and disabled on system startup
etc/
etc/modules-load.d/
etc/modules-load.d/containerd.conf
etc/sysctl.d/
etc/sysctl.d/99-kubernetes-cri.conf
* Applying /etc/sysctl.d/10-console-messages.conf ...
kernel.printk = 4 4 1 7
* Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
net.ipv6.conf.all.use_tempaddr = 2
net.ipv6.conf.default.use_tempaddr = 2
* Applying /etc/sysctl.d/10-kernel-hardening.conf ...
kernel.kptr_restrict = 1
* Applying /etc/sysctl.d/10-link-restrictions.conf ...
fs.protected_hardlinks = 1
fs.protected_symlinks = 1
* Applying /etc/sysctl.d/10-magic-sysrq.conf ...
kernel.sysrq = 176
* Applying /etc/sysctl.d/10-network-security.conf ...
net.ipv4.conf.default.rp_filter = 2
net.ipv4.conf.all.rp_filter = 2
* Applying /etc/sysctl.d/10-ptrace.conf ...
kernel.yama.ptrace_scope = 1
* Applying /etc/sysctl.d/10-zeropage.conf ...
vm.mmap_min_addr = 65536
* Applying /usr/lib/sysctl.d/50-default.conf ...
```



[KAAP-634]: https://platform9.atlassian.net/browse/KAAP-634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the BYOH agent service upgrade process and containerd installation flow by implementing a systemd service for asynchronous upgrades with improved logging and error handling. It also refactors containerd installation to use tar extraction and dynamic configuration generation, resulting in more streamlined installation and upgrade processes on target nodes.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>