### PR TITLE
 KAAP-675: Shorten the byohost label patching if it exceeds 63 characters

### DIFF
--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -22,6 +22,12 @@ const (
 	BundleLookupBaseRegistryAnnotation = "byoh.infrastructure.cluster.x-k8s.io/bundle-registry"
 	// ClusterLabel label is used to mark a cluster where it is attached to
 	ClusterLabel = "kaapi.pf9.io/cluster-name"
+	// Max k8s label value length
+	MaxK8sLabelValueLength = 63
+	LabelHashLength        = 8 // Using 8 chars of SHA256 hex
+	LabelSeparator         = "-"
+	// Max length for the prefix part of the byomachine.namespace.byomachine.name combination
+	MaxLabelPrefixLength = MaxK8sLabelValueLength - LabelHashLength - len(LabelSeparator) // 54
 )
 
 // ByoHostSpec defines the desired state of ByoHost


### PR DESCRIPTION
Fixes: KAAP-675

Byomachine controller patches a label to its attached byohost with the format  <namespace>.<machine_name>.
We have faced an issue where this length exceeds 63 chars limit. 

Updated the code to apply a shorten logic to patch a byohost only if <namespace>.<machine_name> exceeds 63 chars.

Testing: 

Created a cluster with max allowed characters limit.
cluster name: `longest-cluster-name-1`
byomachine: `longest-cluster-name-1-b4668af3-4zmx6-67lb8`

Below is the shorten label used to patch the byohost - 
`byoh.infrastructure.cluster.x-k8s.io/byomachine-name: du-on-devdp4-default-service.longest-cluster-name-1-b4-b4f5bfc4`

Logic: 

original value: `du-on-devdp4-default-service.longest-cluster-name-1-b4668af3-4zmx6-67lb8`
original value exceeds 63 chars. 

Truncate original val to MaxLabelPrefixLength ( check code ) which is 54. Add separator and 8 char sha256 hash.

```
ubuntu@kaapi-dev-51:~$ echo -n du-on-devdp4-default-service.longest-cluster-name-1-b4668af3-4zmx6-67lb8 | sha256sum | cut -c1-8
b4f5bfc4
```



**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
--> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances label handling in infrastructure APIs and controllers by adding constants and a helper function that enforces length restrictions. It implements a safer approach by replacing direct string concatenation with a function that generates hash suffixes when needed, resulting in more robust and reliable cluster labeling.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>