### PR TITLE
kaap-770 : Do apt-get update as a part of onboard

### DIFF
--- a/cmd/byohctl/service/constants.go
+++ b/cmd/byohctl/service/constants.go
@@ -13,7 +13,7 @@ const (
 	DefaultFilePerms = 0644
 
 	// ByohAgentDebPackageURL is the URL to download the agent package
-	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.160"
+	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.200"
 	// ByohAgentDebPackageFilename is the filename of the agent package
 	ByohAgentDebPackageFilename = "pf9-byohost-agent.deb"
 	// ByohAgentServiceName is the name of the agent service


### PR DESCRIPTION
Fixes KAAP-770.

Before - 

```
root@ip-172-31-3-210:~# byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe -t service -r regionone -p's0upnaz1'
[2025-06-13 10:07:52] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-06-13 10:07:55] [SUCCESS] Successfully obtained authentication token
[2025-06-13 10:07:55] [SUCCESS] Successfully retrieved secret
[2025-06-13 10:07:55] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-06-13 10:07:56] [SUCCESS] Installed imgpkg v0.45.0
[2025-06-13 10:07:56] [ERROR] Failed to setup agent: failed to install required packages: failed to install ebtables: exit status 100
Output: Reading package lists...
Building dependency tree...
Reading state information...
Package ebtables is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  netbase

E: Package 'ebtables' has no installation candidate
```


After - 
EC2 instance - 

```
root@ip-172-31-3-210:~# ./byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe -t service -r regionone -p's0upnaz1'
[2025-06-13 10:08:03] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-06-13 10:08:04] [SUCCESS] Successfully obtained authentication token
[2025-06-13 10:08:04] [SUCCESS] Successfully retrieved secret
[2025-06-13 10:08:04] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-06-13 10:08:55] [SUCCESS] Installed ebtables successfully
[2025-06-13 10:08:59] [SUCCESS] Installed conntrack successfully
[2025-06-13 10:09:03] [SUCCESS] Installed socat successfully
[2025-06-13 10:09:03] [SUCCESS] All required packages installed successfully
[2025-06-13 10:09:08] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-13 10:09:09] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-13 10:09:09] [SUCCESS] Agent setup completed successfully
[2025-06-13 10:09:09] [SUCCESS] Successfully onboarded the host
[2025-06-13 10:09:09] [SUCCESS] BYOH Agent Service logs are available at:
[2025-06-13 10:09:09] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-06-13 10:09:09] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service
```

RSPC host - 

```
root@byoh-new-1:~# ./byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe -t service -r regionone -p's0upnaz1'
[2025-06-13 10:12:43] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-06-13 10:12:45] [SUCCESS] Successfully obtained authentication token
[2025-06-13 10:12:45] [SUCCESS] Successfully retrieved secret
[2025-06-13 10:12:45] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-06-13 10:12:57] [SUCCESS] All required packages installed successfully
[2025-06-13 10:13:03] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-13 10:13:04] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-06-13 10:13:04] [SUCCESS] Agent setup completed successfully
[2025-06-13 10:13:04] [SUCCESS] Successfully onboarded the host
[2025-06-13 10:13:04] [SUCCESS] BYOH Agent Service logs are available at:
[2025-06-13 10:13:04] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-06-13 10:13:04] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
--> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR adds an apt-get update step during onboarding with an apt lock check, improving installation reliability through better logging. The changes make the process more robust by handling apt locks and providing clear success messages. The agent package URL was updated in the constants file to align with a newer version and address previous issues.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>