### PR TITLE
KAAP-784: Add exclud-node-drain annotation on the Machine if last node while deauth/decom

### DIFF
--- a/cmd/byohctl/client/k8s.go
+++ b/cmd/byohctl/client/k8s.go
@@ -421,7 +421,7 @@ func (client *Client) WaitForMachineRefToBeUnset(byoHost *infrastructurev1beta1.
 
 		// Check if machineRef is nil or no longer references the machine
 		if byoHost.Status.MachineRef == nil {
-			utils.LogSuccess("MachineRef successfully unset")
+			utils.LogSuccess("MachineRef unset")
 			return nil
 		}
 

--- a/cmd/byohctl/pkg/host_operations.go
+++ b/cmd/byohctl/pkg/host_operations.go
@@ -130,6 +130,12 @@ func PerformHostOperation(operationType HostOperationType, namespace string) err
 		}
 	}
 
+	// Get the fresh machine object from the server to get the updated machine object
+	unstructuredMachineObj, err = client.GetUnstructuredMachineObject(namespace, machineName)
+	if err != nil {
+		return fmt.Errorf("failed to get machine object: %v", err)
+	}
+
 	// 5. Annonate the respective machine object with "cluster.x-k8s.io/delete-machine"="yes"
 	err = client.AnnotateMachineObject(unstructuredMachineObj, namespace, "cluster.x-k8s.io/delete-machine", "yes")
 	if err != nil {
@@ -152,7 +158,7 @@ func PerformHostOperation(operationType HostOperationType, namespace string) err
 		return fmt.Errorf("failed to wait for machineRef to be unset: %v", err)
 	}
 
-	utils.LogSuccess("machineRef successfully unset for the host")
+	utils.LogSuccess("MachineRef successfully unset for the host")
 
 	// If operation is decommission, delete the byohost object and run dpkg purge
 	if operationType == OperationDecommission {

--- a/cmd/byohctl/pkg/host_operations.go
+++ b/cmd/byohctl/pkg/host_operations.go
@@ -122,6 +122,12 @@ func PerformHostOperation(operationType HostOperationType, namespace string) err
 		if !continueDeauth {
 			return fmt.Errorf("Info: De-auth cancelled by user.")
 		}
+
+		// Since this is the last machine in the cluster, annotate machine objects to exclude the node drain
+		err = client.AnnotateMachineObject(unstructuredMachineObj, namespace, "machine.cluster.x-k8s.io/exclude-node-draining", "")
+		if err != nil {
+			return fmt.Errorf("failed to annotate the last machine object to be deauth: %v", err)
+		}
 	}
 
 	// 5. Annonate the respective machine object with "cluster.x-k8s.io/delete-machine"="yes"


### PR DESCRIPTION
Fixes [KAAP-784](https://platform9.atlassian.net/browse/KAAP-784): 

If the node is the last node in the k8s cluster and when we try to deauth that, the CAPI has changed some policy in draining that node. This is applicable since we have upgraded CAPI to 1.9.0 from June release.

Ref: 
https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20240930-machine-drain-rules.md
https://github.com/kubernetes-sigs/cluster-api/releases/tag/v1.9.0

If the node is the last node in the cluster, applying annotation to exclude drain before we proceed with scaling down MD in deauth.

testing - 

```
 ~/Documents  kubectl get nodes                                                                                                                                                                             ✔  oidc-login 󱃾  10:24:19 PM
NAME                STATUS   ROLES    AGE     VERSION
byoh-june-test      Ready    <none>   6h34m   v1.32.3
byoh-kaapi-test-1   Ready    <none>   4h26m   v1.32.3
```

```
 ~/Documents  kubectl get pods -A                                                                                                                                                                         1 ✘  oidc-login 󱃾  10:24:33 PM
NAMESPACE          NAME                                       READY   STATUS    RESTARTS        AGE
calico-apiserver   calico-apiserver-76f777c8cc-j7zq5          1/1     Running   1 (6h33m ago)   8h
calico-apiserver   calico-apiserver-76f777c8cc-pfnct          1/1     Running   1 (6h33m ago)   8h
calico-system      calico-kube-controllers-f9596bb99-nglp9    1/1     Running   0               8h
calico-system      calico-node-c76nk                          1/1     Running   0               4h26m
calico-system      calico-node-cc7hc                          1/1     Running   0               6h34m
calico-system      calico-typha-746f8f954c-wsnns              1/1     Running   0               6h44m
cert-manager       cert-manager-5bfdd59f99-d2fmp              1/1     Running   0               8h
cert-manager       cert-manager-cainjector-7c68db8899-5kjjt   1/1     Running   1 (6h33m ago)   8h
cert-manager       cert-manager-webhook-574866cddf-m9d5q      1/1     Running   0               8h
kube-system        coredns-796d84c46b-cm77q                   1/1     Running   0               8h
kube-system        coredns-796d84c46b-v9mwt                   1/1     Running   0               8h
kube-system        konnectivity-agent-96vfz                   1/1     Running   0               6h34m
kube-system        konnectivity-agent-9g8d5                   1/1     Running   0               4h26m
kube-system        metrics-server-54cf798c86-9qtl4            2/2     Running   0               8h
kube-system        pf9-kube-proxy-p2twv                       1/1     Running   0               6h34m
kube-system        pf9-kube-proxy-twgrn                       1/1     Running   0               4h26m
kube-system        vcp-proxy-2k98q                            1/1     Running   0               6h34m
kube-system        vcp-proxy-khrbw                            1/1     Running   0               4h26m
tigera-operator    tigera-operator-7b9dcd4cd7-pns48           1/1     Running   0               6h44m
```

Deauth of first node - 

```
root@byoh-kaapi-test-1:~# ./byohctl deauthorise
[2025-06-16 16:57:59] [SUCCESS] Successfully retrieved Kubernetes client
[2025-06-16 16:57:59] [SUCCESS] Successfully retrieved ByoHosts object from the management plane
[2025-06-16 16:57:59] [SUCCESS] Successfully annotated machine object that needs to be removed from the cluster
[2025-06-16 16:57:59] [SUCCESS] Successfully scaled down machine deployment by 1
[2025-06-16 16:58:09] [SUCCESS] MachineRef successfully unset
[2025-06-16 16:58:09] [SUCCESS] machineRef successfully unset for the host
[2025-06-16 16:58:09] [SUCCESS] Successfully deauthorised host from the byo cluster
```

workload cluster status - 

```
 ~/Documents  kubectl get nodes                                                                                                                                                                       ✔  29s  oidc-login 󱃾  10:26:43 PM
NAME             STATUS   ROLES    AGE     VERSION
byoh-june-test   Ready    <none>   6h39m   v1.32.3
```

Pods got shifted to the only remaining node - 

```
~/Documents  kubectl get pods -A -o wide                                                                                                                                                              ✔  7s  oidc-login 󱃾  10:29:22 PM
NAMESPACE          NAME                                       READY   STATUS    RESTARTS        AGE     IP               NODE             NOMINATED NODE   READINESS GATES
calico-apiserver   calico-apiserver-76f777c8cc-j7zq5          1/1     Running   1 (6h38m ago)   8h      10.244.14.17     byoh-june-test   <none>           <none>
calico-apiserver   calico-apiserver-76f777c8cc-pfnct          1/1     Running   1 (6h38m ago)   8h      10.244.14.20     byoh-june-test   <none>           <none>
calico-system      calico-kube-controllers-f9596bb99-nglp9    1/1     Running   0               8h      10.244.14.13     byoh-june-test   <none>           <none>
calico-system      calico-node-cc7hc                          1/1     Running   0               6h39m   10.149.101.162   byoh-june-test   <none>           <none>
calico-system      calico-typha-746f8f954c-wsnns              1/1     Running   0               6h48m   10.149.101.162   byoh-june-test   <none>           <none>
cert-manager       cert-manager-5bfdd59f99-d2fmp              1/1     Running   0               8h      10.244.14.21     byoh-june-test   <none>           <none>
cert-manager       cert-manager-cainjector-7c68db8899-5kjjt   1/1     Running   1 (6h38m ago)   8h      10.244.14.19     byoh-june-test   <none>           <none>
cert-manager       cert-manager-webhook-574866cddf-m9d5q      1/1     Running   0               8h      10.244.14.18     byoh-june-test   <none>           <none>
kube-system        coredns-796d84c46b-cm77q                   1/1     Running   0               8h      10.244.14.15     byoh-june-test   <none>           <none>
kube-system        coredns-796d84c46b-v9mwt                   1/1     Running   0               8h      10.244.14.16     byoh-june-test   <none>           <none>
kube-system        konnectivity-agent-96vfz                   1/1     Running   0               6h39m   10.244.14.11     byoh-june-test   <none>           <none>
kube-system        metrics-server-54cf798c86-9qtl4            2/2     Running   0               8h      10.244.14.14     byoh-june-test   <none>           <none>
kube-system        pf9-kube-proxy-p2twv                       1/1     Running   0               6h39m   10.149.101.162   byoh-june-test   <none>           <none>
kube-system        vcp-proxy-2k98q                            1/1     Running   0               6h39m   10.149.101.162   byoh-june-test   <none>           <none>
tigera-operator    tigera-operator-7b9dcd4cd7-pns48           1/1     Running   0               6h48m   10.149.101.162   byoh-june-test   <none>           <none>
```

Deauth of second node - 

```
root@byoh-june-test:~# ./byohctl deauthorise
[2025-06-16 17:16:49] [SUCCESS] Successfully retrieved Kubernetes client
[2025-06-16 17:16:50] [SUCCESS] Successfully retrieved ByoHosts object from the management plane
Info: Machine deployment replica count is 1. This is the last node in the cluster.
Do you want to continue with de-auth? (y/n): y
[2025-06-16 17:16:58] [SUCCESS] Successfully annotated machine object that needs to be removed from the cluster
[2025-06-16 17:16:59] [SUCCESS] Successfully scaled down machine deployment by 1
[2025-06-16 17:17:34] [SUCCESS] MachineRef unset
[2025-06-16 17:17:34] [SUCCESS] MachineRef successfully unset for the host
[2025-06-16 17:17:34] [SUCCESS] Successfully deauthorised host from the byo cluster
```

workload cluster status now with 0 nodes - 

```
 ~/Documents  kubectl get nodes                                                                                                                                                                       ✔  39s  oidc-login 󱃾  10:45:18 PM
No resources found
 ~/Documents  kubectl get pods -A -o wide                                                                                                                                                              ✔  4s  oidc-login 󱃾  10:54:25 PM
NAMESPACE          NAME                                       READY   STATUS    RESTARTS   AGE     IP       NODE     NOMINATED NODE   READINESS GATES
calico-apiserver   calico-apiserver-76f777c8cc-5fss5          0/1     Pending   0          6m47s   <none>   <none>   <none>           <none>
calico-apiserver   calico-apiserver-76f777c8cc-sfthg          0/1     Pending   0          6m48s   <none>   <none>   <none>           <none>
calico-system      calico-kube-controllers-f9596bb99-g5c4n    0/1     Pending   0          6m48s   <none>   <none>   <none>           <none>
calico-system      calico-typha-746f8f954c-5s6bn              0/1     Pending   0          6m49s   <none>   <none>   <none>           <none>
cert-manager       cert-manager-5bfdd59f99-b4g6t              0/1     Pending   0          6m48s   <none>   <none>   <none>           <none>
cert-manager       cert-manager-cainjector-7c68db8899-gx286   0/1     Pending   0          6m48s   <none>   <none>   <none>           <none>
cert-manager       cert-manager-webhook-574866cddf-pc92m      0/1     Pending   0          6m48s   <none>   <none>   <none>           <none>
kube-system        coredns-796d84c46b-8k2mj                   0/1     Pending   0          6m49s   <none>   <none>   <none>           <none>
kube-system        coredns-796d84c46b-pgkh9                   0/1     Pending   0          6m49s   <none>   <none>   <none>           <none>
kube-system        metrics-server-54cf798c86-xpbqr            0/2     Pending   0          6m49s   <none>   <none>   <none>           <none>
tigera-operator    tigera-operator-7b9dcd4cd7-zdhcb           0/1     Pending   0          6m48s   <none>   <none>   <none>           <none>
```

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
--> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR enhances the deauthorization process when handling the last node in a Kubernetes cluster. It implements functionality to annotate machine objects to bypass node draining in accordance with new CAPI policies. The changes also improve logging consistency across client and host operations components while strengthening error handling during deauth and decommission events.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>

[KAAP-784]: https://platform9.atlassian.net/browse/KAAP-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ