### PR TITLE
Version Bump: Updated Ubuntu from 20.04 to 22.04 in GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build-agent:
-      runs-on: ubuntu-20.04
+      runs-on: ubuntu-22.04
       steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -36,7 +36,7 @@ jobs:
         run: make host-agent-binaries
 
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Check Docker Version
       run: docker --version

--- a/.github/workflows/docs-lint.yaml
+++ b/.github/workflows/docs-lint.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   markdown-link-check:
     name: Broken Links
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@master
     - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
 
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   e2e-pr-blocking:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
       uses: actions/checkout@v3

--- a/.github/workflows/lgtm.yaml
+++ b/.github/workflows/lgtm.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   execute:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: jpmcb/prow-github-actions@v1.1.3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   golangci:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Install Go 1.20.7
       uses: actions/setup-go@v4

--- a/.github/workflows/prow-github-actions.yaml
+++ b/.github/workflows/prow-github-actions.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   execute:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: jpmcb/prow-github-actions@v1.1.3
         with:

--- a/.github/workflows/pull-request-labeler.yaml
+++ b/.github/workflows/pull-request-labeler.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   triage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Label pull requests based on the file paths
         uses: actions/labeler@v3

--- a/controllers/infrastructure/k8sinstallerconfig_controller.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller.go
@@ -254,7 +254,7 @@ func (r *K8sInstallerConfigReconciler) storeInstallationData(ctx context.Context
 	scope.Config.Status.Ready = true
 	logger.Info("created installation and uninstallation secrets")
 
-	// ✅ Persist the status update
+	// Persist the status update
 	if err := r.Status().Update(ctx, scope.Config); err != nil {
 		return errors.Wrapf(err, "failed to update K8sInstallerConfig status with installation/uninstallation secret references")
 	}


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates the Ubuntu version from 20.04 to 22.04 across multiple GitHub workflow files, enhancing CI environment security and configuration consistency. It also includes a minor cleanup by removing an unnecessary emoji from a controller file comment, improving code readability without affecting core functionality.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>