### PR TITLE
KAAP-548: Changes in cmd to remove tenant from required flag and setting default as service

### DIFF
--- a/cmd/byohctl/cmd/onboard.go
+++ b/cmd/byohctl/cmd/onboard.go
@@ -42,22 +42,33 @@ This command will:
 }
 
 func init() {
-	onboardCmd.Flags().StringVarP(&fqdn, "url", "u", "", "Platform9 FQDN")
-	onboardCmd.MarkFlagRequired("url")
-	onboardCmd.Flags().StringVarP(&username, "username", "e", "", "Platform9 username")
-	onboardCmd.MarkFlagRequired("username")
-	onboardCmd.Flags().StringVarP(&password, "password", "p", "", "Platform9 password")
-	onboardCmd.Flags().BoolVar(&passwordInteractive, "password-interactive", false, "Enter password interactively")
-	onboardCmd.Flags().StringVarP(&clientToken, "client-token", "c", "", "Client token for authentication")
-	onboardCmd.MarkFlagRequired("client-token")
-	onboardCmd.Flags().StringVarP(&domain, "domain", "d", "default", "Platform9 domain")
-	onboardCmd.Flags().StringVarP(&tenant, "tenant", "t", "service", "Platform9 tenant")
-	onboardCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
-	onboardCmd.MarkFlagsMutuallyExclusive("password", "password-interactive")
-	onboardCmd.Flags().StringVarP(&regionName, "region", "r", "", "Platform9 region where you want to onboard this host")
-	onboardCmd.MarkFlagRequired("region")
-
+	AddOnboardFlags(
+		onboardCmd,
+		&fqdn, &username, &password, &passwordInteractive,
+		&clientToken, &domain, &tenant, &verbosity, &regionName,
+	)
 	rootCmd.AddCommand(onboardCmd)
+}
+
+// AddOnboardFlags adds all flags for the onboard command to the given cobra.Command.
+func AddOnboardFlags(cmd *cobra.Command,
+	fqdn *string, username *string, password *string, passwordInteractive *bool,
+	clientToken *string, domain *string, tenant *string, verbosity *string, regionName *string,
+) {
+	cmd.Flags().StringVarP(fqdn, "url", "u", "", "Platform9 FQDN")
+	cmd.MarkFlagRequired("url")
+	cmd.Flags().StringVarP(username, "username", "e", "", "Platform9 username")
+	cmd.MarkFlagRequired("username")
+	cmd.Flags().StringVarP(password, "password", "p", "", "Platform9 password")
+	cmd.Flags().BoolVar(passwordInteractive, "password-interactive", false, "Enter password interactively")
+	cmd.Flags().StringVarP(clientToken, "client-token", "c", "", "Client token for authentication")
+	cmd.MarkFlagRequired("client-token")
+	cmd.Flags().StringVarP(domain, "domain", "d", "default", "Platform9 domain")
+	cmd.Flags().StringVarP(tenant, "tenant", "t", "service", "Platform9 tenant")
+	cmd.Flags().StringVarP(verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
+	cmd.MarkFlagsMutuallyExclusive("password", "password-interactive")
+	cmd.Flags().StringVarP(regionName, "region", "r", "", "Platform9 region where you want to onboard this host")
+	cmd.MarkFlagRequired("region")
 }
 
 // Check if running on Ubuntu

--- a/cmd/byohctl/cmd/onboard_test.go
+++ b/cmd/byohctl/cmd/onboard_test.go
@@ -89,7 +89,7 @@ func TestOnboardFlags(t *testing.T) {
 	if clientToken != "custom-token" {
 		t.Errorf("Expected client-token 'custom-token', got '%s'", clientToken)
 	}
-	
+
 	if verbosity != "debug" {
 		t.Errorf("Expected verbosity 'debug', got '%s'", verbosity)
 	}
@@ -127,7 +127,7 @@ func TestMutexFlags(t *testing.T) {
 }
 
 func TestRequiredFlags(t *testing.T) {
-	requiredFlags := []string{"username", "fqdn", "tenant", "client-token"}
+	requiredFlags := []string{"username", "fqdn", "client-token"}
 
 	for _, flagName := range requiredFlags {
 		t.Run("missing "+flagName, func(t *testing.T) {
@@ -167,6 +167,13 @@ func TestRequiredFlags(t *testing.T) {
 			if !strings.Contains(outputStr, "required") && !strings.Contains(outputStr, flagName) {
 				t.Errorf("Expected error message about required flag %s, got: %s", flagName, outputStr)
 			}
+
+			// If tenant is not provided, it should default to 'service'
+			if flagName == "tenant" {
+				if tenant != "service" {
+					t.Errorf("Expected default tenant 'service', got '%s'", tenant)
+				}
+			}
 		})
 	}
 }
@@ -190,7 +197,7 @@ func createTestCommand() *cobra.Command {
 	testCmd.Flags().BoolVarP(&passwordInteractive, "interactive", "i", false, "Prompt for password interactively")
 	testCmd.Flags().StringVarP(&fqdn, "fqdn", "f", "", "Platform9 FQDN")
 	testCmd.Flags().StringVarP(&domain, "domain", "d", "default", "Domain name")
-	testCmd.Flags().StringVarP(&tenant, "tenant", "t", "", "Tenant name")
+	testCmd.Flags().StringVarP(&tenant, "tenant", "t", "service", "Tenant name")
 	testCmd.Flags().StringVarP(&clientToken, "client-token", "c", "", "Client token for authentication")
 	testCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level")
 
@@ -201,7 +208,6 @@ func createTestCommand() *cobra.Command {
 	testCmd.MarkFlagRequired("username")
 	testCmd.MarkFlagRequired("fqdn")
 	testCmd.MarkFlagRequired("client-token")
-	testCmd.MarkFlagRequired("tenant")
 
 	return testCmd
 }

--- a/cmd/byohctl/cmd/onboard_test.go
+++ b/cmd/byohctl/cmd/onboard_test.go
@@ -192,22 +192,20 @@ func createTestCommand() *cobra.Command {
 	}
 
 	// Add the same flags as onboardCmd
-	testCmd.Flags().StringVarP(&username, "username", "u", "", "Username for authentication")
-	testCmd.Flags().StringVarP(&password, "password", "p", "", "Password for authentication")
-	testCmd.Flags().BoolVarP(&passwordInteractive, "interactive", "i", false, "Prompt for password interactively")
-	testCmd.Flags().StringVarP(&fqdn, "fqdn", "f", "", "Platform9 FQDN")
-	testCmd.Flags().StringVarP(&domain, "domain", "d", "default", "Domain name")
-	testCmd.Flags().StringVarP(&tenant, "tenant", "t", "service", "Tenant name")
-	testCmd.Flags().StringVarP(&clientToken, "client-token", "c", "", "Client token for authentication")
-	testCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level")
-
-	// Mark mutual exclusivity
-	testCmd.MarkFlagsMutuallyExclusive("password", "interactive")
-
-	// Mark required flags
+	testCmd.Flags().StringVarP(&fqdn, "url", "u", "", "Platform9 FQDN")
+	testCmd.MarkFlagRequired("url")
+	testCmd.Flags().StringVarP(&username, "username", "e", "", "Platform9 username")
 	testCmd.MarkFlagRequired("username")
-	testCmd.MarkFlagRequired("fqdn")
+	testCmd.Flags().StringVarP(&password, "password", "p", "", "Platform9 password")
+	testCmd.Flags().BoolVar(&passwordInteractive, "password-interactive", false, "Enter password interactively")
+	testCmd.Flags().StringVarP(&clientToken, "client-token", "c", "", "Client token for authentication")
 	testCmd.MarkFlagRequired("client-token")
+	testCmd.Flags().StringVarP(&domain, "domain", "d", "default", "Platform9 domain")
+	testCmd.Flags().StringVarP(&tenant, "tenant", "t", "service", "Platform9 tenant")
+	testCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
+	testCmd.MarkFlagsMutuallyExclusive("password", "password-interactive")
+	testCmd.Flags().StringVarP(&regionName, "region", "r", "", "Platform9 region where you want to onboard this host")
+	testCmd.MarkFlagRequired("region")
 
 	return testCmd
 }

--- a/cmd/byohctl/cmd/onboard_test.go
+++ b/cmd/byohctl/cmd/onboard_test.go
@@ -19,6 +19,7 @@ func TestOnboardFlags(t *testing.T) {
 	origTenant := tenant
 	origClientToken := clientToken
 	origVerbosity := verbosity
+	origRegionName := regionName
 
 	defer func() {
 		// Restore original values
@@ -30,6 +31,7 @@ func TestOnboardFlags(t *testing.T) {
 		tenant = origTenant
 		clientToken = origClientToken
 		verbosity = origVerbosity
+		regionName = origRegionName
 	}()
 
 	// Reset global flags
@@ -41,7 +43,7 @@ func TestOnboardFlags(t *testing.T) {
 	tenant = ""
 	clientToken = ""
 	verbosity = ""
-
+	regionName = ""
 	// Create a new test command with the same flag setup
 	testCmd := createTestCommand()
 
@@ -93,6 +95,10 @@ func TestOnboardFlags(t *testing.T) {
 
 	if verbosity != "debug" {
 		t.Errorf("Expected verbosity 'debug', got '%s'", verbosity)
+	}
+
+	if regionName != "test-region" {
+		t.Errorf("Expected region 'test-region', got '%s'", regionName)
 	}
 }
 
@@ -210,20 +216,11 @@ func createTestCommand() *cobra.Command {
 	}
 
 	// Add the same flags as onboardCmd
-	testCmd.Flags().StringVarP(&fqdn, "url", "u", "", "Platform9 FQDN")
-	testCmd.MarkFlagRequired("url")
-	testCmd.Flags().StringVarP(&username, "username", "e", "", "Platform9 username")
-	testCmd.MarkFlagRequired("username")
-	testCmd.Flags().StringVarP(&password, "password", "p", "", "Platform9 password")
-	testCmd.Flags().BoolVar(&passwordInteractive, "password-interactive", false, "Enter password interactively")
-	testCmd.Flags().StringVarP(&clientToken, "client-token", "c", "", "Client token for authentication")
-	testCmd.MarkFlagRequired("client-token")
-	testCmd.Flags().StringVarP(&domain, "domain", "d", "default", "Platform9 domain")
-	testCmd.Flags().StringVarP(&tenant, "tenant", "t", "service", "Platform9 tenant")
-	testCmd.Flags().StringVarP(&verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
-	testCmd.MarkFlagsMutuallyExclusive("password", "password-interactive")
-	testCmd.Flags().StringVarP(&regionName, "region", "r", "", "Platform9 region where you want to onboard this host")
-	testCmd.MarkFlagRequired("region")
+	AddOnboardFlags(
+		testCmd,
+		&fqdn, &username, &password, &passwordInteractive,
+		&clientToken, &domain, &tenant, &verbosity, &regionName,
+	)
 
 	return testCmd
 }


### PR DESCRIPTION
Made changes in the onboard_test.go in cmd file to remove tenant from required flag and set default as "service" 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR refines onboarding command flag handling by consolidating flag definitions into a dedicated function. It removes the tenant flag as a required parameter, sets 'service' as the default value, and adds the '--region' flag across command and test files. The changes include replacing '--fqdn' with '--url', updating error handling, and adjusting test conditions to verify tenant behavior when the flag is omitted.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>