### PR TITLE
kaap-834: Introduce heartbeat mechanism for byohosts.

### DIFF
--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -80,6 +80,19 @@ type ByoHostStatus struct {
 	// network interfaces.
 	// +optional
 	Network []NetworkStatus `json:"network,omitempty"`
+
+	// LastHeartbeatTime is the last time the agent sent a heartbeat.
+	// This is used by the controller to determine if the host is still active.
+	// +optional
+	LastHeartbeatTime *metav1.Time `json:"lastHeartbeatTime,omitempty"`
+
+	// Connected defines if the heartbeat is successfully received from the agent.
+	// +optional
+	Connected bool `json:"connected"`
+
+	// LastHeartbeatCheckTime is the last time the controller checked for heartbeat.
+	// +optional
+	LastHeartbeatCheckTime *metav1.Time `json:"lastHeartbeatCheckTime,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/apis/infrastructure/v1beta1/condition_consts.go
+++ b/apis/infrastructure/v1beta1/condition_consts.go
@@ -85,3 +85,15 @@ const (
 	// or the resource is marked with Paused annotation
 	ClusterOrResourcePausedReason = "ClusterOrResourcePaused"
 )
+
+// AgentConnectedCondition is a condition that indicates whether the agent
+// on the host is connected and sending heartbeats.
+const (
+	AgentConnectedCondition clusterv1.ConditionType = "AgentConnected"
+
+	// HeartbeatReceivedReason is used when a heartbeat is received within the timeout.
+	HeartbeatReceivedReason string = "HeartbeatReceived"
+
+	// HeartbeatTimeoutReason is used when a heartbeat is not received within the timeout.
+	HeartbeatTimeoutReason string = "HeartbeatTimeout"
+)

--- a/chart-generator/byoh-chart/manager_extraconfig_patch.yaml
+++ b/chart-generator/byoh-chart/manager_extraconfig_patch.yaml
@@ -9,3 +9,5 @@ spec:
       containers:
       - name: manager
         image: "{{ .Values.byohImage }}"
+        args:
+          - "--byohostagent-heartbeat-timeout={{ .Values.byohostAgentHeartbeatTimeout | default \"120s\" }}"

--- a/chart-generator/sample-values.yaml
+++ b/chart-generator/sample-values.yaml
@@ -1,1 +1,2 @@
 byohImage: __CONTROLLER_IMAGE__
+byohostAgentHeartbeatTimeout: 120s

--- a/cmd/byohctl/service/constants.go
+++ b/cmd/byohctl/service/constants.go
@@ -13,7 +13,7 @@ const (
 	DefaultFilePerms = 0644
 
 	// ByohAgentDebPackageURL is the URL to download the agent package
-	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.200"
+	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.276"
 	// ByohAgentDebPackageFilename is the filename of the agent package
 	ByohAgentDebPackageFilename = "pf9-byohost-agent.deb"
 	// ByohAgentServiceName is the name of the agent service

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_byohosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_byohosts.yaml
@@ -251,6 +251,17 @@ spec:
                       description: The Operating System reported by the host.
                       type: string
                   type: object
+                lastHeartbeatTime:
+                  description: LastHeartbeatTime is the last time the agent sent a heartbeat.
+                  format: date-time
+                  type: string
+                connected:
+                  description: Connected defines if the heartbeat is successfully received from the agent.
+                  type: boolean
+                lastHeartbeatCheckTime:
+                  description: LastHeartbeatCheckTime is the last time the controller checked for heartbeat.
+                  format: date-time
+                  type: string
                 machineRef:
                   description: |-
                     MachineRef is an optional reference to a Cluster API Machine

--- a/controllers/infrastructure/byohost_controller.go
+++ b/controllers/infrastructure/byohost_controller.go
@@ -5,13 +5,18 @@ package controllers
 
 import (
 	"context"
+	"time"
 
+	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-
-	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 )
 
 // ByoHostReconciler reconciles a ByoHost object
@@ -19,6 +24,25 @@ type ByoHostReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients ( byomachine in this case )
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+const (
+	// ByohHostReconcilePeriod is the duration to wait before requeueing the ByoHost.
+	ByohHostReconcilePeriod = 60 * time.Second
+)
+
+// HeartbeatTimeoutPeriod defines the duration after which the agent is
+// considered to be disconnected.  Its value can be overridden at start-up
+// via the --byohostagent-heartbeat-timeout flag in main.go.
+var HeartbeatTimeoutPeriod = 120 * time.Second
 
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=byohosts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=byohosts/status,verbs=get;update;patch
@@ -35,8 +59,36 @@ type ByoHostReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ByoHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	_ = log.FromContext(ctx)
-	return ctrl.Result{}, nil
+	logger := log.FromContext(ctx)
+	byoHost := &infrastructurev1beta1.ByoHost{}
+	if err := r.Get(ctx, req.NamespacedName, byoHost); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Check if last heartbeat timeout is within the HeartbeatTimeoutPeriod
+	if byoHost.Status.LastHeartbeatTime != nil && time.Since(byoHost.Status.LastHeartbeatTime.Time) < HeartbeatTimeoutPeriod {
+		logger.Info("Heartbeat within timeout period")
+		byoHost.Status.Connected = true
+		conditions.MarkTrue(byoHost, infrastructurev1beta1.AgentConnectedCondition)
+	} else {
+		logger.Info("Heartbeat timeout detected", "HeartbeatTimeoutPeriod", HeartbeatTimeoutPeriod)
+		byoHost.Status.Connected = false
+		conditions.MarkFalse(byoHost, infrastructurev1beta1.AgentConnectedCondition, infrastructurev1beta1.HeartbeatTimeoutReason, clusterv1.ConditionSeverityWarning, "Heartbeat timeout detected")
+	}
+
+	// Update the ByoHost LastHeartbeatCheckTime
+	now := metav1.Now()
+	byoHost.Status.LastHeartbeatCheckTime = &now
+	err := retry.RetryOnConflict(DefaultRetry, func() error {
+		return r.Client.Status().Update(ctx, byoHost)
+	})
+	if err != nil {
+		logger.Error(err, "Failed to update ByoHost status")
+		return ctrl.Result{}, err
+	}
+
+	logger.Info("Reconcile request received")
+	return ctrl.Result{RequeueAfter: ByohHostReconcilePeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/main.go
+++ b/main.go
@@ -113,11 +113,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	byohcontrollers.HeartbeatTimeoutPeriod = byohostAgentHeartbeatTimeout
-
 	if err = (&byohcontrollers.ByoHostReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:                 mgr.GetClient(),
+		Scheme:                 mgr.GetScheme(),
+		HeartbeatTimeoutPeriod: byohostAgentHeartbeatTimeout,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ByoHost")
 		os.Exit(1)


### PR DESCRIPTION
[kaap-834](https://platform9.atlassian.net/browse/KAAP-834)

<img width="1649" height="670" alt="image" src="https://github.com/user-attachments/assets/c5e53d90-df02-4dcb-992c-d36cbc32387a" />


byohost-controller reconciles after every `ByohHostReconcilePeriod` which is 60 seconds - validates if `lastHeartbeatTime` is within configurable `HeartbeatTimeoutPeriod` ( defaults to 120 seconds ) and accordingly updates byohost status conditions, connected field and `lastHeartbeatCheckTime`.

Updated agent side host_reconciler to reconcile every time with the change in the status field of respective byohost by adding `ResourceVersionChangedPredicate` predicate. At every reconciliation, host_reconciler updates `lastHeartbeatTime`. 

Testing: 

```
root@testbyoh:~# systemctl status pf9-byohost-agent.service
● pf9-byohost-agent.service - Platform9 Kubernetes Management Agent Service
     Loaded: loaded (/etc/systemd/system/pf9-byohost-agent.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2025-07-15 15:42:53 UTC; 5min ago
   Main PID: 2684 (bash)
      Tasks: 9 (limit: 4647)
     Memory: 12.4M
        CPU: 301ms
     CGroup: /system.slice/pf9-byohost-agent.service
             ├─2684 /bin/bash -c "/binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig \"\$BOOTSTRAP_KUBECONFIG\" --namespace \"\$NAMESPACE\" --label \"\$REGION\" >> /var/log/pf9/byoh/byoh-agent.log 2>&1"
             └─2685 /binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig /etc/pf9-byohost-agent.service.d/bootstrap-kubeconfig.yaml --namespace du-on-devdp4-default-service --label pcd-kaapi.pf9.io/region=regionone

Jul 15 15:42:53 testbyoh systemd[1]: Started Platform9 Kubernetes Management Agent Service.

status:
  conditions:
  - lastTransitionTime: "2025-07-15T15:42:54Z"
    status: "True"
    type: AgentConnected
  - lastTransitionTime: "2025-07-15T15:42:54Z"
    reason: WaitingForMachineRefToBeAssigned
    severity: Info
    status: "False"
    type: K8sNodeBootstrapSucceeded
  connected: true
  hostinfo:
    architecture: amd64
    osimage: Ubuntu 22.04.2 LTS
    osname: linux
  lastHeartbeatCheckTime: "2025-07-15T15:42:54Z"
  lastHeartbeatTime: "2025-07-15T15:42:54Z"
  network:
  - connected: true
    ipAddrs:
    - 127.0.0.1/8
    - ::1/128
    macAddr: ""
    networkInterfaceName: lo
  - connected: true
    ipAddrs:
    - 10.149.101.101/24
    - fe80::f816:3eff:fe64:dad2/64
    isDefault: true
    macAddr: fa:16:3e:64:da:d2
    networkInterfaceName: ens3
``` 

If either the agent service is stopped or the machine is down ( which will anyway stop the service )

```
root@testbyoh:~# systemctl stop pf9-byohost-agent.service
root@testbyoh:~# systemctl status pf9-byohost-agent.service
○ pf9-byohost-agent.service - Platform9 Kubernetes Management Agent Service
     Loaded: loaded (/etc/systemd/system/pf9-byohost-agent.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Tue 2025-07-15 17:12:24 UTC; 2s ago
    Process: 2684 ExecStart=/bin/bash -c /binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig "$BOOTSTRAP_KUBECONFIG" --namespace "$NAMESPACE" --label "$REGION" >> /var/log/pf9/byoh/byoh-agent.log 2>&1 (code=killed, signal=TERM)
   Main PID: 2684 (code=killed, signal=TERM)
        CPU: 2.652s

Jul 15 15:42:53 testbyoh systemd[1]: Started Platform9 Kubernetes Management Agent Service.
Jul 15 17:12:24 testbyoh systemd[1]: Stopping Platform9 Kubernetes Management Agent Service...
Jul 15 17:12:24 testbyoh systemd[1]: pf9-byohost-agent.service: Deactivated successfully.
Jul 15 17:12:24 testbyoh systemd[1]: Stopped Platform9 Kubernetes Management Agent Service.
Jul 15 17:12:24 testbyoh systemd[1]: pf9-byohost-agent.service: Consumed 2.652s CPU time.


status:
  conditions:
  - lastTransitionTime: "2025-07-15T17:15:55Z"
    message: Heartbeat timeout detected
    reason: HeartbeatTimeout
    severity: Warning
    status: "False"
    type: AgentConnected
  - lastTransitionTime: "2025-07-15T15:42:54Z"
    reason: WaitingForMachineRefToBeAssigned
    severity: Info
    status: "False"
    type: K8sNodeBootstrapSucceeded
  connected: false
  hostinfo:
    architecture: amd64
    osimage: Ubuntu 22.04.2 LTS
    osname: linux
  lastHeartbeatCheckTime: "2025-07-15T17:15:55Z"
  lastHeartbeatTime: "2025-07-15T17:11:55Z"
  network:
  - connected: true
    ipAddrs:
    - 127.0.0.1/8
    - ::1/128
    macAddr: ""
    networkInterfaceName: lo
  - connected: true
    ipAddrs:
    - 10.149.101.101/24
    - fe80::f816:3eff:fe64:dad2/64
    isDefault: true
    macAddr: fa:16:3e:64:da:d2
    networkInterfaceName: ens3
```

Starting service again - 

```
root@testbyoh:~# systemctl start pf9-byohost-agent.service
root@testbyoh:~# systemctl status pf9-byohost-agent.service
● pf9-byohost-agent.service - Platform9 Kubernetes Management Agent Service
     Loaded: loaded (/etc/systemd/system/pf9-byohost-agent.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2025-07-15 17:16:58 UTC; 2s ago
   Main PID: 2767 (bash)
      Tasks: 9 (limit: 4647)
     Memory: 12.2M
        CPU: 120ms
     CGroup: /system.slice/pf9-byohost-agent.service
             ├─2767 /bin/bash -c "/binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig \"\$BOOTSTRAP_KUBECONFIG\" --namespace \"\$NAMESPACE\" --label \"\$REGION\" >> /var/log/pf9/byoh/byoh-agent.log 2>&1"
             └─2768 /binary/pf9-byoh-hostagent-linux-amd64 --bootstrap-kubeconfig /etc/pf9-byohost-agent.service.d/bootstrap-kubeconfig.yaml --namespace du-on-devdp4-default-service --label pcd-kaapi.pf9.io/region=regionone

Jul 15 17:16:58 testbyoh systemd[1]: Started Platform9 Kubernetes Management Agent Service.


status:
  conditions:
  - lastTransitionTime: "2025-07-15T17:16:59Z"
    status: "True"
    type: AgentConnected
  - lastTransitionTime: "2025-07-15T15:42:54Z"
    reason: WaitingForMachineRefToBeAssigned
    severity: Info
    status: "False"
    type: K8sNodeBootstrapSucceeded
  connected: true
  hostinfo:
    architecture: amd64
    osimage: Ubuntu 22.04.2 LTS
    osname: linux
  lastHeartbeatCheckTime: "2025-07-15T17:16:59Z"
  lastHeartbeatTime: "2025-07-15T17:16:59Z"
  network:
  - connected: true
    ipAddrs:
    - 127.0.0.1/8
    - ::1/128
    macAddr: ""
    networkInterfaceName: lo
  - connected: true
    ipAddrs:
    - 10.149.101.101/24
    - fe80::f816:3eff:fe64:dad2/64
    isDefault: true
    macAddr: fa:16:3e:64:da:d2
    networkInterfaceName: ens3
``` 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR implements and enhances a heartbeat mechanism for monitoring byohost connectivity with a configurable timeout period and refined validation logic. The changes include CRD schema updates, configuration improvements through chart updates, improved logging, and condition checks for better host connectivity monitoring. Updates to controller and main application components ensure proper timeout value usage and system reliability.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>