### PR TITLE
KAAP-483: Added functionality of Accept input values from a config file for onboarding node in byohctl

### DIFF
--- a/cmd/byohctl/cmd/onboard.go
+++ b/cmd/byohctl/cmd/onboard.go
@@ -63,19 +63,19 @@ func AddOnboardFlags(cmd *cobra.Command,
 	clientToken *string, domain *string, tenant *string, verbosity *string, regionName *string, configFile *string,
 ) {
 	cmd.Flags().StringVarP(fqdn, "url", "u", "", "Platform9 FQDN")
-	cmd.MarkFlagRequired("url")
+	// cmd.MarkFlagRequired("url")
 	cmd.Flags().StringVarP(username, "username", "e", "", "Platform9 username")
-	cmd.MarkFlagRequired("username")
+	// cmd.MarkFlagRequired("username")
 	cmd.Flags().StringVarP(password, "password", "p", "", "Platform9 password")
 	cmd.Flags().BoolVar(passwordInteractive, "password-interactive", false, "Enter password interactively")
 	cmd.Flags().StringVarP(clientToken, "client-token", "c", "", "Client token for authentication")
-	cmd.MarkFlagRequired("client-token")
+	// cmd.MarkFlagRequired("client-token")
 	cmd.Flags().StringVarP(domain, "domain", "d", "default", "Platform9 domain")
 	cmd.Flags().StringVarP(tenant, "tenant", "t", "service", "Platform9 tenant")
 	cmd.Flags().StringVarP(verbosity, "verbosity", "v", "minimal", "Log verbosity level (all, important, minimal, critical, none)")
 	cmd.MarkFlagsMutuallyExclusive("password", "password-interactive")
 	cmd.Flags().StringVarP(regionName, "region", "r", "", "Platform9 region where you want to onboard this host")
-	cmd.MarkFlagRequired("region")
+	// cmd.MarkFlagRequired("region")
 	cmd.Flags().StringVarP(configFile, "config", "f", "", "Path to onboarding config YAML file")
 }
 
@@ -155,16 +155,16 @@ func runOnboard(cmd *cobra.Command, args []string) {
 
 	missing := []string{}
 	if fqdn == "" {
-		missing = append(missing, "--url")
+		missing = append(missing, "--url (or config file 'url")
 	}
 	if username == "" {
-		missing = append(missing, "--username")
+        missing = append(missing, "--username (or config file 'username')")
 	}
 	if clientToken == "" {
-		missing = append(missing, "--client-token")
+        missing = append(missing, "--client-token (or config file 'client-token')")
 	}
 	if regionName == "" {
-		missing = append(missing, "--region")
+        missing = append(missing, "--region (or config file 'region')")
 	}
 	if len(missing) > 0 {
 		fmt.Printf("Error: missing required flags: %s\n", strings.Join(missing, ", "))
@@ -173,8 +173,6 @@ func runOnboard(cmd *cobra.Command, args []string) {
 
 	utils.LogDebug("Final onboarding values: url=%s, username=%s, domain=%s, tenant=%s, region=%s, verbosity=%s",
 		fqdn, username, domain, tenant, regionName, verbosity)
-
-	// Step 8: (Unit tests for config/flag precedence should be added/updated in onboard_test.go)
 
 	// Check if running on Ubuntu system
 	if !isUbuntuSystem() {

--- a/cmd/byohctl/cmd/onboard_test.go
+++ b/cmd/byohctl/cmd/onboard_test.go
@@ -174,9 +174,8 @@ func TestRequiredFlags(t *testing.T) {
 				t.Errorf("Expected error when missing required flag %s, but got nil", flagName)
 			}
 
-			// Check if the error message contains information about the required flag
 			outputStr := output.String()
-			if !strings.Contains(outputStr, "required") && !strings.Contains(outputStr, flagName) {
+			if !strings.Contains(outputStr, "Error: missing required values") || !strings.Contains(outputStr, flagName) {
 				t.Errorf("Expected error message about required flag %s, got: %s", flagName, outputStr)
 			}
 		})


### PR DESCRIPTION
added functionality of onboarding a host using a config file.

`root@harsh-byohctl:/home/ubuntu# byohctl onboard --config onboard-config.yaml
[2025-07-17 14:05:19] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-07-17 14:05:21] [SUCCESS] Successfully obtained authentication token
[2025-07-17 14:05:21] [SUCCESS] Successfully retrieved secret
[2025-07-17 14:05:21] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-07-17 14:05:21] [SUCCESS] Updating apt packages...Might take few seconds
[2025-07-17 14:05:34] [SUCCESS] All required packages installed successfully
[2025-07-17 14:05:36] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-07-17 14:05:37] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-07-17 14:05:37] [SUCCESS] Agent setup completed successfully
[2025-07-17 14:05:37] [SUCCESS] Successfully onboarded the host
[2025-07-17 14:05:37] [SUCCESS] BYOH Agent Service logs are available at:
[2025-07-17 14:05:37] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-07-17 14:05:37] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service`

So now host onbarding can be done with the command as well as bfore

`root@harsh-byohctl:/home/ubuntu# byohctl onboard -u du-on-devdp4.app.dev-pcd.platform9.com -e admin@platform9.com -d default -c y1Qlb0xQ4dMHtEQe  -r regionone -p s0upnaz1
[2025-07-17 14:09:54] [SUCCESS] Byoh service is not installed, proceeding with onboarding
[2025-07-17 14:09:56] [SUCCESS] Successfully obtained authentication token
[2025-07-17 14:09:56] [SUCCESS] Successfully retrieved secret
[2025-07-17 14:09:56] [SUCCESS] Successfully wrote kubeconfig to /root/.byoh/config
[2025-07-17 14:09:56] [SUCCESS] Updating apt packages...Might take few seconds
[2025-07-17 14:10:04] [SUCCESS] All required packages installed successfully
[2025-07-17 14:10:06] [SUCCESS] Downloaded package to /root/.byoh/packages/pf9-byohost-agent.deb
[2025-07-17 14:10:07] [SUCCESS] Successfully installed Debian package /root/.byoh/packages/pf9-byohost-agent.deb
[2025-07-17 14:10:07] [SUCCESS] Agent setup completed successfully
[2025-07-17 14:10:07] [SUCCESS] Successfully onboarded the host
[2025-07-17 14:10:07] [SUCCESS] BYOH Agent Service logs are available at:
[2025-07-17 14:10:07] [SUCCESS]    - Agent service logs: /var/log/pf9/byoh/byoh-agent.log
[2025-07-17 14:10:07] [SUCCESS]    - Check service status: sudo systemctl status pf9-byohost-agent.service`

