### PR TITLE
KAAP-797 Remove dependency on  Dex Client Secret 

### DIFF
--- a/cmd/byohctl/client/auth.go
+++ b/cmd/byohctl/client/auth.go
@@ -46,7 +46,7 @@ func (c *AuthClient) GetToken(username, password string) (string, error) {
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("pcd:")))
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("platform9-ui:")))
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return "", utils.LogErrorf("failed to authenticate: %v", err)

--- a/cmd/byohctl/client/auth.go
+++ b/cmd/byohctl/client/auth.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -34,12 +35,11 @@ func (c *AuthClient) GetToken(username, password string) (string, error) {
 	utils.LogDebug("Getting authentication token for user %s", username)
 	tokenEndpoint := fmt.Sprintf("https://%s/dex/token", c.fqdn)
 	formData := url.Values{
-		"grant_type":    {"password"},
-		"client_id":     {"kubernetes"},
-		"client_secret": {c.clientToken},
-		"username":      {username},
-		"password":      {password},
-		"scope":         {"openid offline_access groups federated:id email"},
+		"grant_type": {"password"},
+		"client_id":  {"pcd"},
+		"username":   {username},
+		"password":   {password},
+		"scope":      {"openid offline_access groups federated:id email"},
 	}
 
 	req, err := http.NewRequest("POST", tokenEndpoint, strings.NewReader(formData.Encode()))
@@ -48,6 +48,7 @@ func (c *AuthClient) GetToken(username, password string) (string, error) {
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte("pcd:")))
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return "", utils.LogErrorf("failed to authenticate: %v", err)

--- a/cmd/byohctl/client/auth.go
+++ b/cmd/byohctl/client/auth.go
@@ -15,16 +15,14 @@ import (
 )
 
 type AuthClient struct {
-	client      *http.Client
-	fqdn        string
-	clientToken string
+	client *http.Client
+	fqdn   string
 }
 
-func NewAuthClient(fqdn, clientToken string) *AuthClient {
+func NewAuthClient(fqdn string) *AuthClient {
 	return &AuthClient{
-		client:      &http.Client{Timeout: 30 * time.Second},
-		fqdn:        fqdn,
-		clientToken: clientToken,
+		client: &http.Client{Timeout: 30 * time.Second},
+		fqdn:   fqdn,
 	}
 }
 

--- a/cmd/byohctl/client/auth.go
+++ b/cmd/byohctl/client/auth.go
@@ -34,7 +34,7 @@ func (c *AuthClient) GetToken(username, password string) (string, error) {
 	tokenEndpoint := fmt.Sprintf("https://%s/dex/token", c.fqdn)
 	formData := url.Values{
 		"grant_type": {"password"},
-		"client_id":  {"pcd"},
+		"client_id":  {"platform9-ui"},
 		"username":   {username},
 		"password":   {password},
 		"scope":      {"openid offline_access groups federated:id email"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously user needed to provide a client token but now just the username and password is sufficient. 

### Testing notes

- Rebase off latest main
- Build a new byohctl binary at this commit
- Onboard a new host with this binary

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
--> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request refactors the authentication mechanism by eliminating the dependency on the Dex Client Secret. It updates the Authorization header from 'pcd:' to 'platform9-ui:' credentials in the client authentication file and removes clientToken usage across client and onboard modules, resulting in a more streamlined and secure authentication process.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2
-->
</div>