### PR TITLE
 KAAP-782: Check to not disable CRI plugin and restart containerd to reflect the changes in containerd config

### DIFF
--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -53,7 +53,10 @@ mkdir -p /etc/containerd
 containerd config default > /etc/containerd/config.toml
 {{.ContainerdConfig}}
 
+# remove cri as a disabled plugins from containerd config
+sed -i 's/^disabled_plugins = \["cri"\]/disabled_plugins = \[\]/' /etc/containerd/config.toml
+
 ## starting containerd service
-systemctl daemon-reload && systemctl enable containerd && systemctl start containerd
+systemctl daemon-reload && systemctl enable containerd && systemctl restart containerd
 
 echo "Installation complete!"


### PR DESCRIPTION
Fixes [KAAP-782](https://platform9.atlassian.net/issues/KAAP-782)

We start the containerd while untaring `containerd.tar` from the bundle. 
After that we make change in the its config to make systemdCgroup set to true for containerd to work with k8s BUT to reflect this change we don't restart the service. 
Service restart is required as per the [docs here](https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd).


Logs of GPU enabled EC2 byohost: 

```
I0722 09:52:11.936524    2786 host_reconciler.go:169]  "msg"="executing install script" "ByoHost"={"name":"ip-172-31-13-138","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="ip-172-31-13-138" "namespace"="du-on-devdp4-default-service" "reconcileID"="07cce619-74d4-46b9-94ab-37d2479a4c92"
+ BUNDLE_DOWNLOAD_PATH=/var/lib/byoh/bundles
+ BUNDLE_ADDR=quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3
+ IMGPKG_VERSION=v0.36.4
+ ARCH=amd64
+ BUNDLE_PATH=/var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3
+ command -v imgpkg
+ echo 'downloading bundle'
downloading bundle
+ mkdir -p /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3
+ imgpkg pull -i quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3 -o /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3
+ swapoff -a
+ sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+ command -v ufw
+ ufw disable
Firewall stopped and disabled on system startup
+ modprobe overlay
+ modprobe br_netfilter
+ tar -C / -xvf /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/conf.tar
etc/
etc/modules-load.d/
etc/modules-load.d/containerd.conf
etc/sysctl.d/
etc/sysctl.d/99-kubernetes-cri.conf
+ sysctl --system
* Applying /etc/sysctl.d/10-console-messages.conf ...
kernel.printk = 4 4 1 7
* Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
net.ipv6.conf.all.use_tempaddr = 2
net.ipv6.conf.default.use_tempaddr = 2
* Applying /etc/sysctl.d/10-kernel-hardening.conf ...
kernel.kptr_restrict = 1
* Applying /etc/sysctl.d/10-magic-sysrq.conf ...
kernel.sysrq = 176
* Applying /etc/sysctl.d/10-network-security.conf ...
net.ipv4.conf.default.rp_filter = 2
net.ipv4.conf.all.rp_filter = 2
* Applying /etc/sysctl.d/10-ptrace.conf ...
kernel.yama.ptrace_scope = 1
* Applying /etc/sysctl.d/10-zeropage.conf ...
vm.mmap_min_addr = 65536
* Applying /etc/sysctl.d/50-cloudimg-settings.conf ...
net.ipv4.neigh.default.gc_thresh2 = 15360
net.ipv4.neigh.default.gc_thresh3 = 16384
net.netfilter.nf_conntrack_max = 1048576
* Applying /usr/lib/sysctl.d/50-default.conf ...
kernel.core_uses_pid = 1
net.ipv4.conf.default.rp_filter = 2
net.ipv4.conf.default.accept_source_route = 0
sysctl: setting key "net.ipv4.conf.all.accept_source_route": Invalid argument
net.ipv4.conf.default.promote_secondaries = 1
sysctl: setting key "net.ipv4.conf.all.promote_secondaries": Invalid argument
net.ipv4.ping_group_range = 0 2147483647
net.core.default_qdisc = fq_codel
fs.protected_hardlinks = 1
fs.protected_symlinks = 1
fs.protected_regular = 1
fs.protected_fifos = 1
* Applying /usr/lib/sysctl.d/50-pid-max.conf ...
kernel.pid_max = 4194304
* Applying /etc/sysctl.d/99-cloudimg-ipv6.conf ...
net.ipv6.conf.all.use_tempaddr = 0
net.ipv6.conf.default.use_tempaddr = 0
* Applying /etc/sysctl.d/99-kubernetes-cri.conf ...
net.bridge.bridge-nf-call-iptables = 1
net.ipv4.ip_forward = 1
net.bridge.bridge-nf-call-ip6tables = 1
* Applying /usr/lib/sysctl.d/99-protect-links.conf ...
fs.protected_fifos = 1
fs.protected_hardlinks = 1
fs.protected_regular = 2
fs.protected_symlinks = 1
* Applying /etc/sysctl.d/99-sysctl.conf ...
* Applying /etc/sysctl.conf ...
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/cri-tools.deb
Selecting previously unselected package cri-tools.
(Reading database ... 83767 files and directories currently installed.)
Preparing to unpack .../cri-tools.deb ...
Unpacking cri-tools (1.32.0-1.1) ...
Setting up cri-tools (1.32.0-1.1) ...
+ apt-mark hold cri-tools
cri-tools set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubernetes-cni.deb
Selecting previously unselected package kubernetes-cni.
(Reading database ... 83771 files and directories currently installed.)
Preparing to unpack .../kubernetes-cni.deb ...
Unpacking kubernetes-cni (1.6.0-1.1) ...
Setting up kubernetes-cni (1.6.0-1.1) ...
+ apt-mark hold kubernetes-cni
kubernetes-cni set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubectl.deb
Selecting previously unselected package kubectl.
(Reading database ... 83799 files and directories currently installed.)
Preparing to unpack .../kubectl.deb ...
Unpacking kubectl (1.32.3-1.1) ...
Setting up kubectl (1.32.3-1.1) ...
+ apt-mark hold kubectl
kubectl set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubelet.deb
Selecting previously unselected package kubelet.
(Reading database ... 83803 files and directories currently installed.)
Preparing to unpack .../kubelet.deb ...
Unpacking kubelet (1.32.3-1.1) ...
Setting up kubelet (1.32.3-1.1) ...
+ apt-mark hold kubelet
kubelet set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubeadm.deb
Selecting previously unselected package kubeadm.
(Reading database ... 83814 files and directories currently installed.)
Preparing to unpack .../kubeadm.deb ...
Unpacking kubeadm (1.32.3-1.1) ...
Setting up kubeadm (1.32.3-1.1) ...
+ apt-mark hold kubeadm
kubeadm set on hold.
+ tar -C / -xvf /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/containerd.tar
cri-containerd.DEPRECATED.txt
etc/
etc/cni/
etc/cni/net.d/
etc/cni/net.d/10-containerd-net.conflist
etc/systemd/
etc/systemd/system/
etc/systemd/system/containerd.service
etc/crictl.yaml
usr/
usr/local/
usr/local/sbin/
usr/local/sbin/runc
usr/local/bin/
usr/local/bin/ctd-decoder
usr/local/bin/crictl
usr/local/bin/ctr
usr/local/bin/containerd-stress
usr/local/bin/containerd-shim
usr/local/bin/containerd
usr/local/bin/containerd-shim-runc-v2
usr/local/bin/critest
usr/local/bin/containerd-shim-runc-v1
opt/
opt/cni/
opt/cni/bin/
opt/cni/bin/bridge
opt/cni/bin/sbr
opt/cni/bin/vlan
opt/cni/bin/dhcp
opt/cni/bin/host-local
opt/cni/bin/ptp
opt/cni/bin/bandwidth
opt/cni/bin/tuning
opt/cni/bin/portmap
opt/cni/bin/vrf
opt/cni/bin/firewall
opt/cni/bin/macvlan
opt/cni/bin/dummy
opt/cni/bin/static
opt/cni/bin/ipvlan
opt/cni/bin/loopback
opt/cni/bin/host-device
opt/containerd/
opt/containerd/cluster/
opt/containerd/cluster/version
opt/containerd/cluster/gce/
opt/containerd/cluster/gce/cloud-init/
opt/containerd/cluster/gce/cloud-init/node.yaml
opt/containerd/cluster/gce/cloud-init/master.yaml
opt/containerd/cluster/gce/cni.template
opt/containerd/cluster/gce/configure.sh
opt/containerd/cluster/gce/env
+ mkdir -p /etc/containerd
+ containerd config default
+ sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+ sed -i 's/^disabled_plugins = \["cri"\]/disabled_plugins = \[\]/' /etc/containerd/config.toml
+ systemctl daemon-reload
+ systemctl enable containerd
Removed /etc/systemd/system/multi-user.target.wants/containerd.service.
Created symlink /etc/systemd/system/multi-user.target.wants/containerd.service → /etc/systemd/system/containerd.service.
+ systemctl restart containerd
+ echo 'Installation complete!'
Installation complete!
I0722 09:52:34.674019    2786 host_reconciler.go:226]  "msg"="cleaning up directory /run/kubeadm/*" "ByoHost"={"name":"ip-172-31-13-138","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="ip-172-31-13-138" "namespace"="du-on-devdp4-default-service" "reconcileID"="07cce619-74d4-46b9-94ab-37d2479a4c92"
I0722 09:52:34.674082    2786 host_reconciler.go:226]  "msg"="cleaning up directory /etc/cni/net.d/*" "ByoHost"={"name":"ip-172-31-13-138","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="ip-172-31-13-138" "namespace"="du-on-devdp4-default-service" "reconcileID"="07cce619-74d4-46b9-94ab-37d2479a4c92"
I0722 09:52:34.674230    2786 host_reconciler.go:313]  "msg"="Bootstraping k8s Node" "ByoHost"={"name":"ip-172-31-13-138","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="ip-172-31-13-138" "namespace"="du-on-devdp4-default-service" "reconcileID"="07cce619-74d4-46b9-94ab-37d2479a4c92"
[preflight] Running pre-flight checks
[preflight] Reading configuration from the "kubeadm-config" ConfigMap in namespace "kube-system"...
[preflight] Use 'kubeadm init phase upload-config --config your-config.yaml' to re-upload it.
W0722 09:52:35.289294    3209 configset.go:78] Warning: No kubeproxy.config.k8s.io/v1alpha1 config is loaded. Continuing without it: configmaps "kube-proxy" is forbidden: User "system:bootstrap:ltdvjy" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
W0722 09:52:35.311216    3209 configset.go:177] error unmarshaling configuration schema.GroupVersionKind{Group:"kubelet.config.k8s.io", Version:"v1beta1", Kind:"KubeletConfiguration"}: strict decoding error: unknown field "mergeDefaultEvictionSettings"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Starting the kubelet
[kubelet-check] Waiting for a healthy kubelet at http://127.0.0.1:10248/healthz. This can take up to 4m0s
[kubelet-check] The kubelet is healthy after 501.498211ms
[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap

This node has joined the cluster:
* Certificate signing request was sent to apiserver and a response was received.
* The Kubelet was informed of the new secure connection details.

Run 'kubectl get nodes' on the control-plane to see this node join the cluster.

I0722 09:52:36.715202    2786 host_reconciler.go:144]  "msg"="k8s node successfully bootstrapped" "ByoHost"="ip-172-31-13-138" "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="ip-172-31-13-138" "namespace"="du-on-devdp4-default-service" "reconcileID"="07cce619-74d4-46b9-94ab-37d2479a4c92"
```

Logs of RSPC byohost - 

```
+ imgpkg pull -i quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3 -o /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3
+ swapoff -a
+ sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
+ command -v ufw
+ ufw disable
Firewall stopped and disabled on system startup
+ modprobe overlay
+ modprobe br_netfilter
+ tar -C / -xvf /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/conf.tar
etc/
etc/modules-load.d/
etc/modules-load.d/containerd.conf
etc/sysctl.d/
etc/sysctl.d/99-kubernetes-cri.conf
+ sysctl --system
* Applying /etc/sysctl.d/10-console-messages.conf ...
kernel.printk = 4 4 1 7
* Applying /etc/sysctl.d/10-ipv6-privacy.conf ...
net.ipv6.conf.all.use_tempaddr = 2
net.ipv6.conf.default.use_tempaddr = 2
* Applying /etc/sysctl.d/10-kernel-hardening.conf ...
kernel.kptr_restrict = 1
* Applying /etc/sysctl.d/10-magic-sysrq.conf ...
kernel.sysrq = 176
* Applying /etc/sysctl.d/10-network-security.conf ...
net.ipv4.conf.default.rp_filter = 2
net.ipv4.conf.all.rp_filter = 2
* Applying /etc/sysctl.d/10-ptrace.conf ...
kernel.yama.ptrace_scope = 1
* Applying /etc/sysctl.d/10-zeropage.conf ...
vm.mmap_min_addr = 65536
* Applying /usr/lib/sysctl.d/50-default.conf ...
kernel.core_uses_pid = 1
net.ipv4.conf.default.rp_filter = 2
net.ipv4.conf.default.accept_source_route = 0
sysctl: setting key "net.ipv4.conf.all.accept_source_route": Invalid argument
net.ipv4.conf.default.promote_secondaries = 1
sysctl: setting key "net.ipv4.conf.all.promote_secondaries": Invalid argument
net.ipv4.ping_group_range = 0 2147483647
net.core.default_qdisc = fq_codel
fs.protected_hardlinks = 1
fs.protected_symlinks = 1
fs.protected_regular = 1
fs.protected_fifos = 1
* Applying /usr/lib/sysctl.d/50-pid-max.conf ...
kernel.pid_max = 4194304
* Applying /etc/sysctl.d/99-cloudimg-ipv6.conf ...
net.ipv6.conf.all.use_tempaddr = 0
net.ipv6.conf.default.use_tempaddr = 0
* Applying /etc/sysctl.d/99-kubernetes-cri.conf ...
net.bridge.bridge-nf-call-iptables = 1
net.ipv4.ip_forward = 1
net.bridge.bridge-nf-call-ip6tables = 1
* Applying /usr/lib/sysctl.d/99-protect-links.conf ...
fs.protected_fifos = 1
fs.protected_hardlinks = 1
fs.protected_regular = 2
fs.protected_symlinks = 1
* Applying /etc/sysctl.d/99-sysctl.conf ...
* Applying /etc/sysctl.conf ...
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/cri-tools.deb
(Reading database ... 93961 files and directories currently installed.)
Preparing to unpack .../cri-tools.deb ...
Unpacking cri-tools (1.32.0-1.1) over (1.32.0-1.1) ...
Setting up cri-tools (1.32.0-1.1) ...
+ apt-mark hold cri-tools
cri-tools set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubernetes-cni.deb
(Reading database ... 93961 files and directories currently installed.)
Preparing to unpack .../kubernetes-cni.deb ...
Unpacking kubernetes-cni (1.6.0-1.1) over (1.6.0-1.1) ...
Setting up kubernetes-cni (1.6.0-1.1) ...
+ apt-mark hold kubernetes-cni
kubernetes-cni set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubectl.deb
(Reading database ... 93961 files and directories currently installed.)
Preparing to unpack .../kubectl.deb ...
Unpacking kubectl (1.32.3-1.1) over (1.32.3-1.1) ...
Setting up kubectl (1.32.3-1.1) ...
+ apt-mark hold kubectl
kubectl set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubelet.deb
(Reading database ... 93961 files and directories currently installed.)
Preparing to unpack .../kubelet.deb ...
Unpacking kubelet (1.32.3-1.1) over (1.32.3-1.1) ...
Setting up kubelet (1.32.3-1.1) ...
+ apt-mark hold kubelet
kubelet set on hold.
+ for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm
+ dpkg --install /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/kubeadm.deb
(Reading database ... 93961 files and directories currently installed.)
Preparing to unpack .../kubeadm.deb ...
Unpacking kubeadm (1.32.3-1.1) over (1.32.3-1.1) ...
Setting up kubeadm (1.32.3-1.1) ...
+ apt-mark hold kubeadm
kubeadm set on hold.
+ tar -C / -xvf /var/lib/byoh/bundles/quay.io/platform9/byoh-bundle-ubuntu_22.04_x86-64_k8s:v1.32.3/containerd.tar
cri-containerd.DEPRECATED.txt
etc/
etc/cni/
etc/cni/net.d/
etc/cni/net.d/10-containerd-net.conflist
etc/systemd/
etc/systemd/system/
etc/systemd/system/containerd.service
etc/crictl.yaml
usr/
usr/local/
usr/local/sbin/
usr/local/sbin/runc
usr/local/bin/
usr/local/bin/ctd-decoder
usr/local/bin/crictl
usr/local/bin/ctr
usr/local/bin/containerd-stress
usr/local/bin/containerd-shim
usr/local/bin/containerd
usr/local/bin/containerd-shim-runc-v2
usr/local/bin/critest
usr/local/bin/containerd-shim-runc-v1
opt/
opt/cni/
opt/cni/bin/
opt/cni/bin/bridge
opt/cni/bin/sbr
opt/cni/bin/vlan
opt/cni/bin/dhcp
opt/cni/bin/host-local
opt/cni/bin/ptp
opt/cni/bin/bandwidth
opt/cni/bin/tuning
opt/cni/bin/portmap
opt/cni/bin/vrf
opt/cni/bin/firewall
opt/cni/bin/macvlan
opt/cni/bin/dummy
opt/cni/bin/static
opt/cni/bin/ipvlan
opt/cni/bin/loopback
opt/cni/bin/host-device
opt/containerd/
opt/containerd/cluster/
opt/containerd/cluster/version
opt/containerd/cluster/gce/
opt/containerd/cluster/gce/cloud-init/
opt/containerd/cluster/gce/cloud-init/node.yaml
opt/containerd/cluster/gce/cloud-init/master.yaml
opt/containerd/cluster/gce/cni.template
opt/containerd/cluster/gce/configure.sh
opt/containerd/cluster/gce/env
+ mkdir -p /etc/containerd
+ containerd config default
+ sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+ sed -i 's/^disabled_plugins = \["cri"\]/disabled_plugins = \[\]/' /etc/containerd/config.toml
+ systemctl daemon-reload
+ systemctl enable containerd
+ systemctl restart containerd
+ echo 'Installation complete!'
Installation complete!
I0722 10:02:18.424526  355697 host_reconciler.go:226]  "msg"="cleaning up directory /run/kubeadm/*" "ByoHost"={"name":"testbyoh-1","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="testbyoh-1" "namespace"="du-on-devdp4-default-service" "reconcileID"="8fe4718c-1ef7-405f-ad02-e7a45854f914"
I0722 10:02:18.425562  355697 host_reconciler.go:226]  "msg"="cleaning up directory /etc/cni/net.d/*" "ByoHost"={"name":"testbyoh-1","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="testbyoh-1" "namespace"="du-on-devdp4-default-service" "reconcileID"="8fe4718c-1ef7-405f-ad02-e7a45854f914"
I0722 10:02:18.425924  355697 host_reconciler.go:313]  "msg"="Bootstraping k8s Node" "ByoHost"={"name":"testbyoh-1","namespace":"du-on-devdp4-default-service"} "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="testbyoh-1" "namespace"="du-on-devdp4-default-service" "reconcileID"="8fe4718c-1ef7-405f-ad02-e7a45854f914"
[preflight] Running pre-flight checks
[preflight] Reading configuration from the "kubeadm-config" ConfigMap in namespace "kube-system"...
[preflight] Use 'kubeadm init phase upload-config --config your-config.yaml' to re-upload it.
W0722 10:02:19.360930  356144 configset.go:78] Warning: No kubeproxy.config.k8s.io/v1alpha1 config is loaded. Continuing without it: configmaps "kube-proxy" is forbidden: User "system:bootstrap:xvmu1z" cannot get resource "configmaps" in API group "" in the namespace "kube-system"
W0722 10:02:19.400796  356144 configset.go:177] error unmarshaling configuration schema.GroupVersionKind{Group:"kubelet.config.k8s.io", Version:"v1beta1", Kind:"KubeletConfiguration"}: strict decoding error: unknown field "mergeDefaultEvictionSettings"
[kubelet-start] Writing kubelet configuration to file "/var/lib/kubelet/config.yaml"
[kubelet-start] Writing kubelet environment file with flags to file "/var/lib/kubelet/kubeadm-flags.env"
[kubelet-start] Starting the kubelet
[kubelet-check] Waiting for a healthy kubelet at http://127.0.0.1:10248/healthz. This can take up to 4m0s
[kubelet-check] The kubelet is healthy after 1.001176403s
[kubelet-start] Waiting for the kubelet to perform the TLS Bootstrap

This node has joined the cluster:
* Certificate signing request was sent to apiserver and a response was received.
* The Kubelet was informed of the new secure connection details.

Run 'kubectl get nodes' on the control-plane to see this node join the cluster.

I0722 10:02:20.898297  355697 host_reconciler.go:144]  "msg"="k8s node successfully bootstrapped" "ByoHost"="testbyoh-1" "controller"="byohost" "controllerGroup"="infrastructure.cluster.x-k8s.io" "controllerKind"="ByoHost" "name"="testbyoh-1" "namespace"="du-on-devdp4-default-service" "reconcileID"="8fe4718c-1ef7-405f-ad0
```

One node in the below workload cluster is the ec2 host with ubuntu22 ( GPU supporting ) and flavour 4dn.xlarge while another is RSPC host.

<img width="1920" height="1080" alt="Screenshot 2025-07-22 at 3 37 10 PM (2)" src="https://github.com/user-attachments/assets/63f17b33-b534-439c-820a-5616df659060" />

[KAAP-782]: https://platform9.atlassian.net/browse/KAAP-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR updates containerd configuration by removing the CRI plugin from disabled plugins list using sed commands. It also modifies service commands to properly reload and restart containerd, ensuring new settings are correctly applied. These changes address misconfiguration issues that could impact service behavior.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>