### PR TITLE
KAAP-519: Download kubelet, kubectl and cri-tools binaries from k8s / cri repo not APT

### DIFF
--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -11,6 +11,8 @@ export BUNDLE_VERSION=${BUNDLE_VERSION:-v1.32.2}
 export ARCH=${ARCH:-amd64}
 export CRITOOL_VERSION=${CRITOOL_VERSION:-1.32.0-1.1}
 export UBUNTU_VERSION=${UBUNTU_VERSION:-"22.04"} # Default to 22.04, can be overridden
+export OS=${OS:-linux}
+export CNI_VERSION=${CNI_VERSION:-1.3.0}
 
 #alias shasum="sha512sum"
 echo "installing imgpkg"

--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -27,7 +27,7 @@ docker build -t byoh-bundle .
 docker rm -f byoh-bundle-container
 
 echo "executing docker image"
-docker run -e CRITOOL_VERSION -e BUILD_ONLY -e CONTAINERD_VERSION -e KUBERNETES_VERSION -e KUBERNETES_MAJOR_VERSION -e ARCH -e UBUNTU_VERSION --name byoh-bundle-container -i byoh-bundle /bin/bash
+docker run -e CRITOOL_VERSION -e BUILD_ONLY -e CONTAINERD_VERSION -e KUBERNETES_VERSION -e KUBERNETES_MAJOR_VERSION -e ARCH -e UBUNTU_VERSION -e OS -e CNI_VERSION --name byoh-bundle-container -i byoh-bundle /bin/bash
 
 echo "creating bundle dir to push k8s packages"
 mkdir -p ./bundle

--- a/installer/bundle_builder/build-bundle.sh
+++ b/installer/bundle_builder/build-bundle.sh
@@ -16,23 +16,24 @@ ls -l $INGREDIENTS_PATH
 
 cd /bundle
 echo Strip version to well-known names
-# Mandatory
-cp $INGREDIENTS_PATH/*containerd* containerd.tar
-cp $INGREDIENTS_PATH/*kubeadm*.deb ./kubeadm.deb
-cp $INGREDIENTS_PATH/*kubelet*.deb ./kubelet.deb
-cp $INGREDIENTS_PATH/*kubectl*.deb ./kubectl.deb
-# Optional
-cp  $INGREDIENTS_PATH/*cri-tools*.deb cri-tools.deb > /dev/null | true
-cp  $INGREDIENTS_PATH/*kubernetes-cni*.deb kubernetes-cni.deb > /dev/null | true
+
+cp "$INGREDIENTS_PATH"/kubeadm .
+cp "$INGREDIENTS_PATH"/kubelet .
+cp "$INGREDIENTS_PATH"/kubectl .
+
+cp "$INGREDIENTS_PATH"/cri-containerd-cni-*.tar.gz containerd.tar.gz
+cp "$INGREDIENTS_PATH"/crictl-*.tar.gz crictl.tar.gz
+cp "$INGREDIENTS_PATH"/cni-plugins-*.tgz cni-plugins.tgz
+
 
 echo Configuration $CONFIG_PATH
 ls -l $CONFIG_PATH
 
 echo Add configuration under well-known name
-(cd $CONFIG_PATH && tar -cvf conf.tar *)
-cp $CONFIG_PATH/conf.tar .
+(cd "$CONFIG_PATH" && tar -cvf conf.tar .)
+cp "$CONFIG_PATH"/conf.tar .
 
-echo Creating bundle tar
+echo "Creating BYOH bundle tar..."
 tar -cvf /bundle/bundle.tar *
 
-echo Done
+echo "Done"

--- a/installer/bundle_builder/ingredients/deb/Dockerfile
+++ b/installer/bundle_builder/ingredients/deb/Dockerfile
@@ -15,6 +15,7 @@ FROM $BASE_IMAGE as build
 ENV CONTAINERD_VERSION=1.6.26
 ENV KUBERNETES_VERSION=1.26.6-00
 ENV ARCH=amd64
+ENV OS=linux
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends sudo

--- a/installer/bundle_builder/ingredients/deb/Dockerfile
+++ b/installer/bundle_builder/ingredients/deb/Dockerfile
@@ -16,6 +16,7 @@ ENV CONTAINERD_VERSION=1.6.26
 ENV KUBERNETES_VERSION=1.26.6-00
 ENV ARCH=amd64
 ENV OS=linux
+ENV CNI_VERSION=1.3.0
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends sudo

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -7,11 +7,11 @@ set -e
 
 echo "Starting BYOH bundle ingredient download..."
 
-:"${ARCH:?ARCH must be set}"
-:"${OS:?OS must be set}"
-:"${CONTAINERD_VERSION:?CONTAINERD_VERSION must be set}"
-:"${KUBERNETES_VERSION:?KUBERNETES_VERSION must be set}"
-:"${CRITOOL_VERSION:?CRITOOL_VERSION must be set}"
+: "${ARCH:?ARCH must be set}"
+: "${OS:?OS must be set}"
+: "${CONTAINERD_VERSION:?CONTAINERD_VERSION must be set}"
+: "${KUBERNETES_VERSION:?KUBERNETES_VERSION must be set}"
+: "${CRITOOL_VERSION:?CRITOOL_VERSION must be set}"
 : "${CNI_VERSION:?CNI_VERSION must be set}"
 
 K8S_VERSION="v${KUBERNETES_VERSION%%-*}"

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -5,29 +5,46 @@
 
 set -e
 
-echo  Update the apt package index and install packages needed to use the Kubernetes apt repository
- apt-get update
- apt-get install -y apt-transport-https ca-certificates curl
+echo "Starting BYOH bundle ingredient download..."
 
-echo Download containerd
-curl -LOJR https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz 
+:"${ARCH:?ARCH must be set}"
+:"${OS:?OS must be set}"
+:"${CONTAINERD_VERSION:?CONTAINERD_VERSION must be set}"
+:"${KUBERNETES_VERSION:?KUBERNETES_VERSION must be set}"
+:"${CRITOOL_VERSION:?CRITOOL_VERSION must be set}"
+: "${CNI_VERSION:?CNI_VERSION must be set}"
 
-echo Download the Google Cloud public signing key
- curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg
+K8S_VERSION="v${KUBERNETES_VERSION%%-*}"
+CRICTL_VERSION="v${CRITOOL_VERSION}"
+CNI_VERSION="v${CNI_VERSION}"
 
-echo Add the Kubernetes apt repository
+mkdir -p /ingredients
 
-echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MAJOR_VERSION}/deb/ /" |  tee /etc/apt/sources.list.d/kubernetes.list
+echo "Downloading containerd..."
+curl -LO "https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-${OS}-${ARCH}.tar.gz"
+mv "cri-containerd-cni-${CONTAINERD_VERSION}-${OS}-${ARCH}.tar.gz" /ingredients/
 
-mkdir -p /etc/apt/keyrings
-curl -fsSL https://pkgs.k8s.io/core:/stable:/${KUBERNETES_MAJOR_VERSION}/deb/Release.key |  gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo "Downloading crictl..."
+curl -LO "https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-${OS}-${ARCH}.tar.gz"
+mv "crictl-${CRICTL_VERSION}-${OS}-${ARCH}.tar.gz" /ingredients/
 
-echo Update apt package index, install kubelet, kubeadm and kubectl
-apt-get update
-chown -Rv _apt:root /bundle/
-chown -R _apt:root /ingredients
-mv cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz /ingredients/ 
-cd /ingredients 
-apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
-apt-get download kubernetes-cni:$ARCH
-apt-get download cri-tools:$ARCH=$CRITOOL_VERSION
+echo "Downloading kubeadm..."
+curl -LO "https://dl.k8s.io/release/${K8S_VERSION}/bin/${OS}/${ARCH}/kubeadm"
+chmod +x kubeadm
+mv kubeadm /ingredients/
+
+echo "Downloading kubelet..."
+curl -LO "https://dl.k8s.io/release/${K8S_VERSION}/bin/${OS}/${ARCH}/kubelet"
+chmod +x kubelet
+mv kubelet /ingredients/
+
+echo "Downloading kubectl..."
+curl -LO "https://dl.k8s.io/release/${K8S_VERSION}/bin/${OS}/${ARCH}/kubectl"
+chmod +x kubectl
+mv kubectl /ingredients/
+
+echo "Downloading CNI plugins..."
+curl -LO "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-${OS}-${ARCH}-${CNI_VERSION}.tgz"
+mv "cni-plugins-${OS}-${ARCH}-${CNI_VERSION}.tgz" /ingredients/
+
+echo "All ingredients downloaded and stored in /ingredients"


### PR DESCRIPTION
**What this PR does / why we need it**:

Changed the way of downloading kubelet, kubectl, kubeadm and cri-tools not from apt but directly downloading it from the repo via curl and adding them to the bundle. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request transitions from apt-based package downloads to direct downloads from remote repositories, refining the bundle builder, Dockerfile, and download script. The changes improve command syntax, update environment variables, and implement curl for fetching binaries. The PR also corrects variable formatting, enhances docker run commands with additional environment variables, and explicitly sets CNI_VERSION in the Dockerfile for a more robust deployment process.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>