### PR TITLE
KAAP-492: added the curl commands to download the dependencies

### DIFF
--- a/installer/bundle_builder/build-bundle.sh
+++ b/installer/bundle_builder/build-bundle.sh
@@ -25,6 +25,12 @@ cp $INGREDIENTS_PATH/*kubectl*.deb ./kubectl.deb
 cp  $INGREDIENTS_PATH/*cri-tools*.deb cri-tools.deb > /dev/null | true
 cp  $INGREDIENTS_PATH/*kubernetes-cni*.deb kubernetes-cni.deb > /dev/null | true
 
+
+cp $INGREDIENTS_PATH/socat*.deb .
+cp $INGREDIENTS_PATH/ethtool*.deb .
+cp $INGREDIENTS_PATH/ebtables*.deb .
+cp $INGREDIENTS_PATH/conntrack*.deb .
+
 echo Configuration $CONFIG_PATH
 ls -l $CONFIG_PATH
 

--- a/installer/bundle_builder/ingredients/deb/download.sh
+++ b/installer/bundle_builder/ingredients/deb/download.sh
@@ -31,3 +31,13 @@ cd /ingredients
 apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
 apt-get download kubernetes-cni:$ARCH
 apt-get download cri-tools:$ARCH=$CRITOOL_VERSION
+
+SOCAT_URL="https://archive.ubuntu.com/ubuntu/pool/main/s/socat/socat_1.7.3.3-2_amd64.deb"
+ETHTOOL_URL="https://archive.ubuntu.com/ubuntu/pool/main/e/ethtool/ethtool_5.4-1_amd64.deb"
+EBTABLES_URL="https://archive.ubuntu.com/ubuntu/pool/main/e/ebtables/ebtables_2.0.10.4-3.4ubuntu1_amd64.deb"
+CONNTRACK_URL="https://archive.ubuntu.com/ubuntu/pool/main/c/conntrack-tools/conntrack_1.4.5-2_amd64.deb"
+
+curl -L -o socat.deb ${SOCAT_URL}
+curl -L -o ethtool.deb ${ETHTOOL_URL}
+curl -L -o ebtables.deb ${EBTABLES_URL}
+curl -L -o conntrack.deb ${CONNTRACK_URL}


### PR DESCRIPTION
**What this PR does / why we need it**:

[KAAP-492](https://platform9.atlassian.net/browse/KAAP-492)

Added the curl commands in download.sh to download the dependencies without using apt.

[KAAP-492]: https://platform9.atlassian.net/browse/KAAP-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances dependency management by adding a 'bundle-deps' Makefile target for streamlined extraction, updating build-bundle.sh to copy additional dependency files, and modifying download.sh to use curl-based downloads instead of some apt-get operations, improving reliability and control in the build pipeline.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>