### PR TITLE
Move kube-rbac-proxy to quay.io

### DIFF
--- a/chart-generator/byoh-chart/manager_auth_proxy_patch.yaml
+++ b/chart-generator/byoh-chart/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.21.2
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
`gcr.io` is deprecated and hence we are seeing ImagePullBackoff for the kube-rbac-proxy container in byoh-controller. 

Hence moving the image to `quay.io/brancz/kube-rbac-proxy:v0.21.2`

Testing -
```
Normal  Pulling    23s   kubelet            spec.containers{kube-rbac-proxy}: Pulling image "quay.io/brancz/kube-rbac-proxy:v0.21.2"
  Normal  Pulled     19s   kubelet            spec.containers{kube-rbac-proxy}: Successfully pulled image "quay.io/brancz/kube-rbac-proxy:v0.21.2" in 3.517s (3.517s including waiting). Image size: 33348063 bytes.
```