### PR TITLE
fix: resolve stuck host agent loop during BYOH cluster scale-down

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -376,6 +376,10 @@ func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrast
 	// Remove BootstrapSecret
 	byoHost.Spec.BootstrapSecret = nil
 
+	// Remove UninstallationSecret reference (secret itself has no owner after Task 1;
+	// clearing the reference avoids a stale pointer on the host after cleanup)
+	byoHost.Spec.UninstallationSecret = nil
+
 	// Remove cluster-name label
 	delete(byoHost.Labels, clusterv1.ClusterNameLabel)
 

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -257,6 +257,10 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 		if err != nil {
 			return err
 		}
+		// Mark the condition False immediately after reset so that if the uninstall
+		// script fetch fails below, subsequent reconciles do not re-run kubeadm reset.
+		// The deferred helper.Patch in Reconcile persists this even when we return an error.
+		conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 		if r.SkipK8sInstallation {
 			logger.Info("Skipping uninstallation of k8s components")
 		} else {
@@ -291,7 +295,6 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 				return err
 			}
 		}
-		conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 		logger.Info("host removed from the cluster and the uninstall is executed successfully")
 	} else {
 		logger.Info("Skipping k8s node reset and k8s component uninstallation")

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -578,8 +578,8 @@ runCmd:
 				Expect(updatedByoHost.Annotations).NotTo(HaveKey(infrastructurev1beta1.EndPointIPAnnotation))
 				Expect(updatedByoHost.Annotations).NotTo(HaveKey(infrastructurev1beta1.K8sVersionAnnotation))
 				Expect(updatedByoHost.Annotations).NotTo(HaveKey(infrastructurev1beta1.BundleLookupBaseRegistryAnnotation))
-				Expect(updatedByoHost.Spec.UninstallationSecret).NotTo(BeNil())
-				Expect(updatedByoHost.Spec.UninstallationSecret.Name).To(Equal(uninstallSecretName))
+				Expect(updatedByoHost.Spec.UninstallationSecret).To(BeNil(),
+					"UninstallationSecret reference should be cleared after successful cleanup")
 
 				k8sNodeBootstrapSucceeded := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded)
 				Expect(*k8sNodeBootstrapSucceeded).To(conditions.MatchCondition(clusterv1.Condition{

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -607,6 +607,35 @@ runCmd:
 				Expect(reconcilerErr).To(MatchError("UninstallationSecret not found in Byohost " + byoHost.Name))
 			})
 
+			It("should not run kubeadm reset a second time when uninstall secret is absent", func() {
+				// First reconcile: kubeadm reset runs, then fails on missing secret
+				byoHost.Spec.UninstallationSecret = nil
+				Expect(patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).NotTo(HaveOccurred())
+
+				_, firstErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
+					NamespacedName: byoHostLookupKey,
+				})
+				Expect(firstErr).To(HaveOccurred())
+				Expect(fakeCommandRunner.RunCmdCallCount()).To(Equal(1), "kubeadm reset must run exactly once on first reconcile")
+				_, firstCmd := fakeCommandRunner.RunCmdArgsForCall(0)
+				Expect(firstCmd).To(Equal(reconciler.KubeadmResetCommand))
+
+				// Reload host state as the reconciler patched it
+				reloadedHost := &infrastructurev1beta1.ByoHost{}
+				Expect(k8sClient.Get(ctx, byoHostLookupKey, reloadedHost)).NotTo(HaveOccurred())
+				k8sComponentsCond := conditions.Get(reloadedHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
+				Expect(k8sComponentsCond).NotTo(BeNil())
+				Expect(k8sComponentsCond.Status).To(Equal(corev1.ConditionFalse),
+					"K8sComponentsInstallationSucceeded must be False after reset so second reconcile skips kubeadm reset")
+
+				// Second reconcile: must NOT run kubeadm reset again
+				_, secondErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
+					NamespacedName: byoHostLookupKey,
+				})
+				Expect(secondErr).ToNot(HaveOccurred())
+				Expect(fakeCommandRunner.RunCmdCallCount()).To(Equal(1), "kubeadm reset must NOT be called again on second reconcile")
+			})
+
 			It("should return error if uninstall script execution failed", func() {
 				fakeCommandRunner.RunCmdReturnsOnCall(1, errors.New("failed to execute uninstall script"))
 				uninstallScript = `testcommand`

--- a/controllers/infrastructure/k8sinstallerconfig_controller.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller.go
@@ -220,7 +220,6 @@ func (r *K8sInstallerConfigReconciler) storeInstallationData(ctx context.Context
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: scope.Cluster.Name,
 			},
-			OwnerReferences: ownerReference,
 		},
 		Data: map[string][]byte{
 			"uninstall": []byte(uninstall),

--- a/controllers/infrastructure/k8sinstallerconfig_controller_test.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller_test.go
@@ -368,6 +368,25 @@ var _ = Describe("Controllers/K8sInstallerConfigController", func() {
 			Expect(updatedConfig.Status.Ready).To(BeTrue())
 		})
 
+		It("should create uninstall secret without owner reference", func() {
+			_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      k8sinstallerConfig.Name,
+					Namespace: k8sinstallerConfig.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			uninstallSecret := &corev1.Secret{}
+			err = k8sClientUncached.Get(ctx, types.NamespacedName{
+				Name:      "byoh-uninstall-" + k8sinstallerConfig.Name,
+				Namespace: k8sinstallerConfig.Namespace,
+			}, uninstallSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uninstallSecret.OwnerReferences).To(BeEmpty(),
+				"uninstall secret must have no owner so it is not GC'd when K8sInstallerConfig is deleted")
+		})
+
 		Context("When K8sInstallerConfig is deleted", func() {
 			BeforeEach(func() {
 				_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{

--- a/controllers/infrastructure/k8sinstallerconfig_controller_test.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller_test.go
@@ -387,6 +387,27 @@ var _ = Describe("Controllers/K8sInstallerConfigController", func() {
 				"uninstall secret must have no owner so it is not GC'd when K8sInstallerConfig is deleted")
 		})
 
+		It("should create install secret with owner reference pointing to K8sInstallerConfig", func() {
+			_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      k8sinstallerConfig.Name,
+					Namespace: k8sinstallerConfig.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			installSecret := &corev1.Secret{}
+			err = k8sClientUncached.Get(ctx, types.NamespacedName{
+				Name:      "byoh-install-" + k8sinstallerConfig.Name,
+				Namespace: k8sinstallerConfig.Namespace,
+			}, installSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(installSecret.OwnerReferences).To(HaveLen(1),
+				"install secret must be owned by K8sInstallerConfig so it is GC'd when provisioning is torn down")
+			Expect(installSecret.OwnerReferences[0].Kind).To(Equal("K8sInstallerConfig"))
+			Expect(installSecret.OwnerReferences[0].Name).To(Equal(k8sinstallerConfig.Name))
+		})
+
 		Context("When K8sInstallerConfig is deleted", func() {
 			BeforeEach(func() {
 				_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{


### PR DESCRIPTION
# Problem
When scaling down a MachineDeployment, the host agent gets stuck in an infinite loop running kubeadm reset and the ByoHost is never freed. Two bugs combine to cause this:

## Bug 1 — Uninstall secret garbage-collected before agent can use it

The uninstall secret (byoh-uninstall-<name>) was created with an OwnerReference pointing to K8sInstallerConfig. During scale-down, ByoMachine deletion cascades to K8sInstallerConfig deletion, which causes Kubernetes GC to immediately delete the uninstall secret — before the on-host agent has a chance to fetch and execute it.

## Bug 2 — kubeadm reset re-runs on every reconcile retry

In hostCleanUp, conditions.MarkFalse(K8sComponentsInstallationSucceeded) was only called at the very end of the success path. If the uninstall secret fetch failed (e.g. due to Bug 1), the function returned early without updating the condition. On the next reconcile the condition was still True, so kubeadm reset ran again — creating an infinite loop visible in agent logs.

# Fix

- k8sinstallerconfig_controller.go — Remove OwnerReferences from the uninstall secret only. The install secret retains its owner (it is only needed during provisioning). The uninstall secret now survives K8sInstallerConfig deletion and is cleaned up explicitly by the agent.

- host_reconciler.go — Move MarkFalse(K8sComponentsInstallationSucceeded) to immediately after resetNode() succeeds, before the uninstall script block. The Reconcile function's deferred helper.Patch persists this condition change even when a subsequent error triggers an early return, so retries skip kubeadm reset and only retry the uninstall script.

- host_reconciler.go:removeAnnotations — Nil out Spec.UninstallationSecret during cleanup so the ByoHost object does not retain a stale reference after the script has been executed.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->