### PR TITLE
chore: bump Trivy 0.69.3→0.70.0, auto-close stale vuln PRs, restrict push to main

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -92,7 +92,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="auto/gosec-scan/${{ env.SAFE_REF_NAME }}"
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [[ -n "$PR_NUMBER" ]]; then
             gh pr close "$PR_NUMBER" --repo "${{ github.repository }}" --comment "No HIGH/CRITICAL vulnerabilities found in latest scan on \`${{ github.ref_name }}\`. Closing report."
           fi
@@ -184,7 +184,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BRANCH="auto/trivy-scan/${{ env.SAFE_REF_NAME }}"
-          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number // empty')
           if [[ -n "$PR_NUMBER" ]]; then
             gh pr close "$PR_NUMBER" --repo "${{ github.repository }}" --comment "No HIGH/CRITICAL vulnerabilities found in latest scan on \`${{ github.ref_name }}\`. Closing report."
           fi

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - private/harsh/soc2-scan
   pull_request:
 
 jobs:
@@ -87,6 +86,17 @@ jobs:
           base: ${{ github.ref_name }}
           delete-branch: true
 
+      - name: Close Stale Vulnerability PR (if clean)
+        if: ${{ github.event_name == 'push' && steps.scan.outputs.gosec_high_found == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/gosec-scan/${{ env.SAFE_REF_NAME }}"
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr close "$PR_NUMBER" --repo "${{ github.repository }}" --comment "No HIGH/CRITICAL vulnerabilities found in latest scan on \`${{ github.ref_name }}\`. Closing report."
+          fi
+
       - name: Fail Job If Vulnerabilities Found
         if: ${{ steps.scan.outputs.gosec_high_found == 'true' }}
         run: exit 1
@@ -111,7 +121,7 @@ jobs:
           wget -qO- https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo tee /etc/apt/trusted.gpg.d/trivy.asc
           echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/trivy.list
           sudo apt update
-          sudo apt install -y trivy=0.69.3 jq
+          sudo apt install -y trivy=0.70.0 jq
 
       - name: Sanitize branch name
         run: echo "SAFE_REF_NAME=${GITHUB_REF_NAME//\//-}" >> $GITHUB_ENV
@@ -167,6 +177,17 @@ jobs:
           branch: auto/trivy-scan/${{ env.SAFE_REF_NAME }}
           base: ${{ github.ref_name }}
           delete-branch: true
+
+      - name: Close Stale Vulnerability PR (if clean)
+        if: ${{ github.event_name == 'push' && steps.scan.outputs.trivy_high_found == 'false' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="auto/trivy-scan/${{ env.SAFE_REF_NAME }}"
+          PR_NUMBER=$(gh pr list --repo "${{ github.repository }}" --head "$BRANCH" --state open --json number --jq '.[0].number')
+          if [[ -n "$PR_NUMBER" ]]; then
+            gh pr close "$PR_NUMBER" --repo "${{ github.repository }}" --comment "No HIGH/CRITICAL vulnerabilities found in latest scan on \`${{ github.ref_name }}\`. Closing report."
+          fi
 
       - name: Fail Job If Vulnerabilities Found
         if: ${{ steps.scan.outputs.trivy_high_found == 'true' }}


### PR DESCRIPTION
## Summary

- Bumps pinned Trivy version in `.github/workflows/security-scan.yml` from `0.69.3` to `0.70.0` (where applicable)
- Adds `Close Stale Vulnerability PR (if clean)` step to each scanner job (gosec/bandit/trivy) — automatically closes the report PR when a subsequent scan finds no HIGH/CRITICAL vulnerabilities
- Restricts `on.push.branches` to `main` only, removing any other branches

## Changes

### Trivy version bump
- `trivy=0.69.3` → `trivy=0.70.0` (apt pattern) or `TRIVY_VERSION: 0.69.3` → `TRIVY_VERSION: 0.70.0` (env var pattern)

### Auto-close stale vulnerability PRs
Adds a close step to each scanner job that runs only on `push` when no HIGH/CRITICAL vulnerabilities are found, finds any open PR on the `auto/<scanner>-scan/<branch>` branch and closes it with a comment.

### Push trigger cleanup
- Removed all non-`main` branches from `on.push.branches`

## Test plan
- [ ] CI installs the correct Trivy version (0.70.0) on this PR
- [ ] Merge a fix to a branch that has an open vulnerability report PR and confirm the report PR is auto-closed
