### PR TITLE
KAAP-2000: Byohost cleanup fixes

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/registration"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/common"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -295,12 +294,6 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 			r.Recorder.Event(byoHost, corev1.EventTypeWarning, "UninstallScriptExecutionFailed", "uninstall script execution failed")
 			return err
 		}
-		// Delete the secret — it has no owner (ownerRef removed in k8sinstallerconfig controller)
-		// so it must be explicitly cleaned up after use.
-		if err := r.Client.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "error deleting uninstallation secret", "secret", secret.Name)
-		}
-		byoHost.Spec.UninstallationSecret = nil
 		logger.Info("host removed from the cluster and the uninstall is executed successfully")
 	} else if r.SkipK8sInstallation {
 		logger.Info("Skipping uninstallation of k8s components")

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -376,6 +376,10 @@ func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrast
 	// Remove BootstrapSecret
 	byoHost.Spec.BootstrapSecret = nil
 
+	// Remove UninstallationSecret reference (secret itself has no owner after Task 1;
+	// clearing the reference avoids a stale pointer on the host after cleanup)
+	byoHost.Spec.UninstallationSecret = nil
+
 	// Remove cluster-name label
 	delete(byoHost.Labels, clusterv1.ClusterNameLabel)
 

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/registration"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/common"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -251,53 +252,58 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("cleaning up host")
 
+	// Guard kubeadm reset behind the installation condition — only run if k8s was installed.
+	// MarkFalse immediately after reset so retries skip reset and only retry the uninstall script.
 	k8sComponentsInstallationSucceeded := conditions.Get(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
 	if k8sComponentsInstallationSucceeded != nil && k8sComponentsInstallationSucceeded.Status == corev1.ConditionTrue {
 		err := r.resetNode(ctx, byoHost)
 		if err != nil {
 			return err
 		}
-		// Mark the condition False immediately after reset so that if the uninstall
-		// script fetch fails below, subsequent reconciles do not re-run kubeadm reset.
-		// The deferred helper.Patch in Reconcile persists this even when we return an error.
 		conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
-		if r.SkipK8sInstallation {
-			logger.Info("Skipping uninstallation of k8s components")
-		} else {
-			logger.Info("Executing Uninstall script")
-			if byoHost.Spec.UninstallationSecret == nil {
-				return fmt.Errorf("UninstallationSecret not found in Byohost %s", byoHost.Name)
-			}
-			secret := &corev1.Secret{}
-			err := r.Client.Get(ctx, types.NamespacedName{
-				Name:      byoHost.Spec.UninstallationSecret.Name,
-				Namespace: byoHost.Spec.UninstallationSecret.Namespace,
-			}, secret)
-			if err != nil {
-				logger.Error(err, "error getting uninstallation script secret")
-				r.Recorder.Eventf(byoHost, corev1.EventTypeWarning, "ReadUninstallationSecretFailed", "uninstallation secret %s not found", byoHost.Spec.UninstallationSecret.Name)
-				return err
-			}
-			uninstallScriptBytes, ok := secret.Data["uninstall"]
-			if !ok {
-				return fmt.Errorf("uninstall script not found in secret %s", secret.Name)
-			}
-			uninstallScript := string(uninstallScriptBytes)
-			uninstallScript, err = r.parseScript(ctx, uninstallScript)
-			if err != nil {
-				logger.Error(err, "error parsing Uninstallation script")
-				return err
-			}
-			err = r.CmdRunner.RunCmd(ctx, uninstallScript)
-			if err != nil {
-				logger.Error(err, "error executing Uninstallation script")
-				r.Recorder.Event(byoHost, corev1.EventTypeWarning, "UninstallScriptExecutionFailed", "uninstall script execution failed")
-				return err
-			}
-		}
-		logger.Info("host removed from the cluster and the uninstall is executed successfully")
 	} else {
-		logger.Info("Skipping k8s node reset and k8s component uninstallation")
+		logger.Info("Skipping k8s node reset")
+	}
+
+	// Guard uninstall script behind UninstallationSecret being set — independent of the reset
+	// condition so that retries after a failed uninstall still execute the script.
+	if !r.SkipK8sInstallation && byoHost.Spec.UninstallationSecret != nil {
+		logger.Info("Executing Uninstall script")
+		secret := &corev1.Secret{}
+		err := r.Client.Get(ctx, types.NamespacedName{
+			Name:      byoHost.Spec.UninstallationSecret.Name,
+			Namespace: byoHost.Spec.UninstallationSecret.Namespace,
+		}, secret)
+		if err != nil {
+			logger.Error(err, "error getting uninstallation script secret")
+			r.Recorder.Eventf(byoHost, corev1.EventTypeWarning, "ReadUninstallationSecretFailed", "uninstallation secret %s not found", byoHost.Spec.UninstallationSecret.Name)
+			return err
+		}
+		uninstallScriptBytes, ok := secret.Data["uninstall"]
+		if !ok {
+			return fmt.Errorf("uninstall script not found in secret %s", secret.Name)
+		}
+		uninstallScript := string(uninstallScriptBytes)
+		uninstallScript, err = r.parseScript(ctx, uninstallScript)
+		if err != nil {
+			logger.Error(err, "error parsing Uninstallation script")
+			return err
+		}
+		err = r.CmdRunner.RunCmd(ctx, uninstallScript)
+		if err != nil {
+			logger.Error(err, "error executing Uninstallation script")
+			r.Recorder.Event(byoHost, corev1.EventTypeWarning, "UninstallScriptExecutionFailed", "uninstall script execution failed")
+			return err
+		}
+		// Delete the secret — it has no owner (ownerRef removed in k8sinstallerconfig controller)
+		// so it must be explicitly cleaned up after use.
+		if err := r.Client.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+			logger.Error(err, "error deleting uninstallation secret", "secret", secret.Name)
+		}
+		byoHost.Spec.UninstallationSecret = nil
+		logger.Info("host removed from the cluster and the uninstall is executed successfully")
+	} else if r.SkipK8sInstallation {
+		logger.Info("Skipping uninstallation of k8s components")
 	}
 	conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 
@@ -375,10 +381,6 @@ func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrast
 
 	// Remove BootstrapSecret
 	byoHost.Spec.BootstrapSecret = nil
-
-	// Remove UninstallationSecret reference (secret itself has no owner after Task 1;
-	// clearing the reference avoids a stale pointer on the host after cleanup)
-	byoHost.Spec.UninstallationSecret = nil
 
 	// Remove cluster-name label
 	delete(byoHost.Labels, clusterv1.ClusterNameLabel)

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -257,6 +257,10 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 		if err != nil {
 			return err
 		}
+		// Mark the condition False immediately after reset so that if the uninstall
+		// script fetch fails below, subsequent reconciles do not re-run kubeadm reset.
+		// The deferred helper.Patch in Reconcile persists this even when we return an error.
+		conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 		if r.SkipK8sInstallation {
 			logger.Info("Skipping uninstallation of k8s components")
 		} else {
@@ -291,7 +295,6 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 				return err
 			}
 		}
-		conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 		logger.Info("host removed from the cluster and the uninstall is executed successfully")
 	} else {
 		logger.Info("Skipping k8s node reset and k8s component uninstallation")

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -578,8 +578,8 @@ runCmd:
 				Expect(updatedByoHost.Annotations).NotTo(HaveKey(infrastructurev1beta1.EndPointIPAnnotation))
 				Expect(updatedByoHost.Annotations).NotTo(HaveKey(infrastructurev1beta1.K8sVersionAnnotation))
 				Expect(updatedByoHost.Annotations).NotTo(HaveKey(infrastructurev1beta1.BundleLookupBaseRegistryAnnotation))
-				Expect(updatedByoHost.Spec.UninstallationSecret).NotTo(BeNil())
-				Expect(updatedByoHost.Spec.UninstallationSecret.Name).To(Equal(uninstallSecretName))
+				Expect(updatedByoHost.Spec.UninstallationSecret).To(BeNil(),
+					"UninstallationSecret reference should be cleared after successful cleanup")
 
 				k8sNodeBootstrapSucceeded := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded)
 				Expect(*k8sNodeBootstrapSucceeded).To(conditions.MatchCondition(clusterv1.Condition{

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -607,6 +607,35 @@ runCmd:
 				Expect(reconcilerErr).To(MatchError("UninstallationSecret not found in Byohost " + byoHost.Name))
 			})
 
+			It("should not run kubeadm reset a second time when uninstall secret is absent", func() {
+				// First reconcile: kubeadm reset runs, then fails on missing secret
+				byoHost.Spec.UninstallationSecret = nil
+				Expect(patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).NotTo(HaveOccurred())
+
+				_, firstErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
+					NamespacedName: byoHostLookupKey,
+				})
+				Expect(firstErr).To(HaveOccurred())
+				Expect(fakeCommandRunner.RunCmdCallCount()).To(Equal(1), "kubeadm reset must run exactly once on first reconcile")
+				_, firstCmd := fakeCommandRunner.RunCmdArgsForCall(0)
+				Expect(firstCmd).To(Equal(reconciler.KubeadmResetCommand))
+
+				// Reload host state as the reconciler patched it
+				reloadedHost := &infrastructurev1beta1.ByoHost{}
+				Expect(k8sClient.Get(ctx, byoHostLookupKey, reloadedHost)).NotTo(HaveOccurred())
+				k8sComponentsCond := conditions.Get(reloadedHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
+				Expect(k8sComponentsCond).NotTo(BeNil())
+				Expect(k8sComponentsCond.Status).To(Equal(corev1.ConditionFalse),
+					"K8sComponentsInstallationSucceeded must be False after reset so second reconcile skips kubeadm reset")
+
+				// Second reconcile: must NOT run kubeadm reset again
+				_, secondErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
+					NamespacedName: byoHostLookupKey,
+				})
+				Expect(secondErr).ToNot(HaveOccurred())
+				Expect(fakeCommandRunner.RunCmdCallCount()).To(Equal(1), "kubeadm reset must NOT be called again on second reconcile")
+			})
+
 			It("should return error if uninstall script execution failed", func() {
 				fakeCommandRunner.RunCmdReturnsOnCall(1, errors.New("failed to execute uninstall script"))
 				uninstallScript = `testcommand`

--- a/cmd/byohctl/service/constants.go
+++ b/cmd/byohctl/service/constants.go
@@ -13,7 +13,7 @@ const (
 	DefaultFilePerms = 0644
 
 	// ByohAgentDebPackageURL is the URL to download the agent package
-	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.200"
+	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.362"
 	// ByohAgentDebPackageFilename is the filename of the agent package
 	ByohAgentDebPackageFilename = "pf9-byohost-agent.deb"
 	// ByohAgentServiceName is the name of the agent service

--- a/cmd/byohctl/service/constants.go
+++ b/cmd/byohctl/service/constants.go
@@ -13,7 +13,7 @@ const (
 	DefaultFilePerms = 0644
 
 	// ByohAgentDebPackageURL is the URL to download the agent package
-	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.362"
+	ByohAgentDebPackageURL = "quay.io/platform9/byoh-agent-deb:0.1.366"
 	// ByohAgentDebPackageFilename is the filename of the agent package
 	ByohAgentDebPackageFilename = "pf9-byohost-agent.deb"
 	// ByohAgentServiceName is the name of the agent service

--- a/controllers/infrastructure/byohost_controller.go
+++ b/controllers/infrastructure/byohost_controller.go
@@ -6,7 +6,10 @@ package controllers
 import (
 	"context"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -24,18 +27,43 @@ type ByoHostReconciler struct {
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=byohosts/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=byohosts/finalizers,verbs=update
 //+kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=create;get;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;delete
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ByoHost object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 func (r *ByoHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
+
+	byoHost := &infrastructurev1beta1.ByoHost{}
+	if err := r.Get(ctx, req.NamespacedName, byoHost); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	// Delete the uninstall secret once the agent has completed cleanup.
+	// The agent removes the cleanup annotation as its final step, so absence of
+	// the annotation combined with no machineRef means the host is fully cleaned up.
+	// The uninstall secret has no ownerReference (by design, to survive K8sInstallerConfig
+	// deletion), so it must be explicitly deleted here by the manager.
+	_, hasCleanupAnnotation := byoHost.GetAnnotations()[infrastructurev1beta1.HostCleanupAnnotation]
+	if byoHost.Spec.UninstallationSecret != nil &&
+		byoHost.Status.MachineRef == nil &&
+		!hasCleanupAnnotation {
+
+		secret := &corev1.Secret{}
+		err := r.Get(ctx, types.NamespacedName{
+			Name:      byoHost.Spec.UninstallationSecret.Name,
+			Namespace: byoHost.Spec.UninstallationSecret.Namespace,
+		}, secret)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+		if err == nil {
+			if delErr := r.Delete(ctx, secret); delErr != nil && !apierrors.IsNotFound(delErr) {
+				logger.Error(delErr, "failed to delete uninstallation secret", "secret", secret.Name)
+				return ctrl.Result{}, delErr
+			}
+			logger.Info("deleted uninstallation secret", "secret", secret.Name)
+		}
+	}
+
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/infrastructure/k8sinstallerconfig_controller.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller.go
@@ -220,7 +220,6 @@ func (r *K8sInstallerConfigReconciler) storeInstallationData(ctx context.Context
 			Labels: map[string]string{
 				clusterv1.ClusterNameLabel: scope.Cluster.Name,
 			},
-			OwnerReferences: ownerReference,
 		},
 		Data: map[string][]byte{
 			"uninstall": []byte(uninstall),

--- a/controllers/infrastructure/k8sinstallerconfig_controller_test.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller_test.go
@@ -368,6 +368,25 @@ var _ = Describe("Controllers/K8sInstallerConfigController", func() {
 			Expect(updatedConfig.Status.Ready).To(BeTrue())
 		})
 
+		It("should create uninstall secret without owner reference", func() {
+			_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      k8sinstallerConfig.Name,
+					Namespace: k8sinstallerConfig.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			uninstallSecret := &corev1.Secret{}
+			err = k8sClientUncached.Get(ctx, types.NamespacedName{
+				Name:      "byoh-uninstall-" + k8sinstallerConfig.Name,
+				Namespace: k8sinstallerConfig.Namespace,
+			}, uninstallSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(uninstallSecret.OwnerReferences).To(BeEmpty(),
+				"uninstall secret must have no owner so it is not GC'd when K8sInstallerConfig is deleted")
+		})
+
 		Context("When K8sInstallerConfig is deleted", func() {
 			BeforeEach(func() {
 				_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{

--- a/controllers/infrastructure/k8sinstallerconfig_controller_test.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller_test.go
@@ -387,6 +387,27 @@ var _ = Describe("Controllers/K8sInstallerConfigController", func() {
 				"uninstall secret must have no owner so it is not GC'd when K8sInstallerConfig is deleted")
 		})
 
+		It("should create install secret with owner reference pointing to K8sInstallerConfig", func() {
+			_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      k8sinstallerConfig.Name,
+					Namespace: k8sinstallerConfig.Namespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			installSecret := &corev1.Secret{}
+			err = k8sClientUncached.Get(ctx, types.NamespacedName{
+				Name:      "byoh-install-" + k8sinstallerConfig.Name,
+				Namespace: k8sinstallerConfig.Namespace,
+			}, installSecret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(installSecret.OwnerReferences).To(HaveLen(1),
+				"install secret must be owned by K8sInstallerConfig so it is GC'd when provisioning is torn down")
+			Expect(installSecret.OwnerReferences[0].Kind).To(Equal("K8sInstallerConfig"))
+			Expect(installSecret.OwnerReferences[0].Name).To(Equal(k8sinstallerConfig.Name))
+		})
+
 		Context("When K8sInstallerConfig is deleted", func() {
 			BeforeEach(func() {
 				_, err := k8sInstallerConfigReconciler.Reconcile(ctx, reconcile.Request{


### PR DESCRIPTION
## What Changed
Five fixes across the manager and agent to resolve an infinite kubeadm reset loop and orphaned uninstall secrets during BYOH cluster scale-down:

- Remove ownerRef from uninstall secret (k8sinstallerconfig_controller.go) — Previously, GC deleted the secret before the agent could use it.

- Separate reset and uninstall guards (agent/reconciler/host_reconciler.go) — kubeadm reset is gated on K8sComponentsInstallationSucceeded=True; uninstall script execution is independently gated on spec.uninstallationSecret being set. Previously both were tied to the same condition, causing the uninstall script to be silently skipped on the second reconcile.

- Persist K8sComponentsInstallationSucceeded=False immediately after kubeadm reset

- Move uninstall secret deletion to manager-side byohost_controller — Manager byohost controller deletes the secret once agent cleanup is confirmed complete (machineRef nil + cleanup annotation gone + uninstallationSecret reference still set).

- Bump byoh agent deb to 0.1.366 (cmd/byohctl/service/constants.go).

## Why
During MachineDeployment scale-down, the BYOH agent was looping infinitely running kubeadm reset on the same host. Root causes:

- GC race: the uninstall secret had an ownerRef on K8sInstallerConfig; when the machine was deleted, K8sInstallerConfig was GC'd first, taking the uninstall secret with it — agent found the secret missing, returned error, never progressed past reset.

- Condition not persisted: K8sComponentsInstallationSucceeded=False was set in memory but not immediately patched to the API server on error return — next reconcile re-read True from the server and ran reset again.

- Guard coupling: after fixing the condition, a design regression emerged where the uninstall script was skipped entirely because both reset and uninstall shared the same condition guard. Separated into independent guards.

- Secret cleanup: after agent completed cleanup, the orphaned uninstall secret (no ownerRef by design) was never deleted. Agent couldn't delete it (RBAC boundary — agent runs on customer hosts). Moved cleanup to manager.

## Uninstall flow 
```mermaid
sequenceDiagram
    participant User
    participant CAPI as CAPI Controller
    participant BYOMachine as ByoMachine Controller
    participant Agent as Host Agent
    participant BYOHost as ByoHost Controller
    participant K8s as Host (k8s node)

    User->>CAPI: apply delete-machine label
    CAPI->>BYOMachine: Machine DeletionTimestamp set
    BYOMachine->>Agent: set HostCleanupAnnotation on ByoHost
    BYOMachine->>BYOMachine: remove ByoMachine finalizer

    Agent->>Agent: detect HostCleanupAnnotation
    alt K8sComponentsInstallationSucceeded=True
        Agent->>K8s: kubeadm reset
        Agent->>Agent: mark K8sComponentsInstallationSucceeded=False (patched immediately)
    end
    alt spec.uninstallationSecret != nil
        Agent->>Agent: fetch uninstall secret
        Agent->>K8s: run uninstall script
    end
    Agent->>Agent: removeAnnotations (clear machineRef, remove cleanup annotation)
    Agent->>Agent: helper.Patch → persist ByoHost changes

    BYOHost->>BYOHost: reconcile triggered by ByoHost patch
    Note over BYOHost: uninstallSecret≠nil + machineRef=nil + no cleanup annotation
    BYOHost->>BYOHost: delete uninstall secret
    Note over Agent,BYOHost: Host is free for reuse

```

## Testing 
Tested on a 3-node `fix-4` cluster (sm-byoh-2, sm-byoh-3, sm-byoh-4) with the new agent deb (0.1.366, git 02e4eb9) and new manager image (0.1.392):

- Triggered scale-down by applying cluster.x-k8s.io/delete-machine label on 2 nodes

- Agent ran kubeadm reset once (no loop) and executed uninstall script successfully

- Manager-side byohost_controller deleted both uninstall secrets after agent completed cleanup, confirmed in manager logs:

```
byohost_controller.go:63  "deleted uninstallation secret"  sm-byoh-2  byoh-uninstall-fix-4-...-h7bwt
byohost_controller.go:63  "deleted uninstallation secret"  sm-byoh-3  byoh-uninstall-fix-4-...-hclct
```

- Remaining active node (sm-byoh-1) and its uninstall secret were untouched

- Removed hosts were available for re-use (registered as free ByoHost objects)

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->