### PR TITLE
fix: preserve UFW state across BYOH node install/uninstall

### DIFF
--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -34,7 +34,9 @@ swapoff -a && sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
 ## disable firewall, save current state so uninstall can restore it
 if command -v ufw >>/dev/null; then
     mkdir -p /var/lib/byoh
-    ufw status | grep -q "Status: active" && echo "active" > /var/lib/byoh/ufw-state || echo "inactive" > /var/lib/byoh/ufw-state
+    if [ ! -f /var/lib/byoh/ufw-state ]; then
+        ufw status | grep -q "Status: active" && echo "active" > /var/lib/byoh/ufw-state || echo "inactive" > /var/lib/byoh/ufw-state
+    fi
     ufw disable
 fi
 

--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -31,8 +31,10 @@ imgpkg pull -i $BUNDLE_ADDR -o $BUNDLE_PATH
 ## disable swap
 swapoff -a && sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
 
-## disable firewall
+## disable firewall, save current state so uninstall can restore it
 if command -v ufw >>/dev/null; then
+    mkdir -p /var/lib/byoh
+    ufw status | grep -q "Status: active" && echo "active" > /var/lib/byoh/ufw-state || echo "inactive" > /var/lib/byoh/ufw-state
     ufw disable
 fi
 

--- a/installer/internal/algo/ubuntu-templates/uninstall.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/uninstall.sh.tmpl
@@ -33,6 +33,7 @@ if command -v ufw >>/dev/null; then
     if [ -f /var/lib/byoh/ufw-state ] && grep -qx "active" /var/lib/byoh/ufw-state; then
         ufw enable
     fi
+    rm -f /var/lib/byoh/ufw-state
 fi
 
 ## enable swap

--- a/installer/internal/algo/ubuntu-templates/uninstall.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/uninstall.sh.tmpl
@@ -30,7 +30,7 @@ modprobe -rq overlay || true && modprobe -r br_netfilter || true
 
 ## restore firewall to its pre-install state
 if command -v ufw >>/dev/null; then
-    if [ -f /var/lib/byoh/ufw-state ] && grep -q "active" /var/lib/byoh/ufw-state; then
+    if [ -f /var/lib/byoh/ufw-state ] && grep -qx "active" /var/lib/byoh/ufw-state; then
         ufw enable
     fi
 fi

--- a/installer/internal/algo/ubuntu-templates/uninstall.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/uninstall.sh.tmpl
@@ -28,9 +28,11 @@ fi
 ## remove kernal modules
 modprobe -rq overlay || true && modprobe -r br_netfilter || true
 
-## enable firewall
+## restore firewall to its pre-install state
 if command -v ufw >>/dev/null; then
-    ufw enable
+    if [ -f /var/lib/byoh/ufw-state ] && grep -q "active" /var/lib/byoh/ufw-state; then
+        ufw enable
+    fi
 fi
 
 ## enable swap


### PR DESCRIPTION
## Problem 
When a BYOH host was removed from a Kubernetes cluster, the uninstall script unconditionally ran ufw enable, enabling the firewall regardless of what state it was in before the host joined the cluster.

On hosts where UFW was disabled before onboarding (the common case for customer-managed infrastructure), this caused permanent SSH access loss after every node scale-down — with no way to recover without console access.

## Fix
Install script — saves UFW state to /var/lib/byoh/ufw-state before disabling it:
Uninstall script — restores UFW only if it was active before install:

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->