### PR TITLE
fix: handle dpkg lock contention 

### DIFF
--- a/installer/internal/algo/ubuntu-templates/install.sh.tmpl
+++ b/installer/internal/algo/ubuntu-templates/install.sh.tmpl
@@ -42,9 +42,13 @@ modprobe overlay && modprobe br_netfilter
 ## adding os configuration
 tar -C / -xvf "$BUNDLE_PATH/conf.tar" && sysctl --system 
 
+## wait for dpkg lock (unattended-upgrades or apt may hold it at boot)
+timeout 300 bash -c 'until flock -n /var/lib/dpkg/lock-frontend true 2>/dev/null; do echo "waiting for dpkg lock..."; sleep 5; done'
+
 ## installing deb packages
 for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm; do
-    dpkg --install "$BUNDLE_PATH/$pkg.deb" && apt-mark hold $pkg
+    dpkg --install "$BUNDLE_PATH/$pkg.deb"
+    apt-mark hold $pkg
 done
 
 ## intalling containerd


### PR DESCRIPTION
## Problem
BYOH hosts could silently fail to install Kubernetes packages during node onboarding, yet report K8sComponentsInstallationSucceeded=True — leaving the host in a permanently broken state 

Two bugs combined to cause this:

- Bug 1 — dpkg failures silently swallowed by set -e
`dpkg --install "$BUNDLE_PATH/$pkg.deb" && apt-mark hold $pkg`
Bash's set -e does not exit on a command that is the left-hand side of && — it is treated as a conditional, not a standalone statement. So if dpkg --install failed (e.g. due to a lock), the error was swallowed, 

- Bug 2 — no wait for the dpkg frontend lock
Ubuntu's unattended-upgrades service holds the dpkg frontend lock for 30–60 seconds. If the BYOH install script ran during this window, all dpkg --install calls would fail with: `dpkg: error: dpkg frontend lock was locked by another process`

The combination of both bugs meant: lock held at boot → all packages silently not installed → kubeadm: command not found on every subsequent reconcile → host stuck forever, manual intervention required.

## Fix

- Separating dpkg and apt-mark onto individual lines means set -e correctly catches a failing dpkg install and aborts the script
- wait for dpkg lock (uses flock)

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->