### PR TITLE
fix: clear spec.uninstallationSecret on ByoHost after secret deletion

### DIFF
--- a/controllers/infrastructure/byohost_controller.go
+++ b/controllers/infrastructure/byohost_controller.go
@@ -48,7 +48,6 @@ func (r *ByoHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 	if byoHost.Spec.UninstallationSecret != nil &&
 		byoHost.Status.MachineRef == nil &&
 		!hasCleanupAnnotation {
-
 		secret := &corev1.Secret{}
 		err := r.Get(ctx, types.NamespacedName{
 			Name:      byoHost.Spec.UninstallationSecret.Name,

--- a/controllers/infrastructure/byohost_controller.go
+++ b/controllers/infrastructure/byohost_controller.go
@@ -5,6 +5,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -58,8 +59,7 @@ func (r *ByoHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		}
 		if err == nil {
 			if delErr := r.Delete(ctx, secret); delErr != nil && !apierrors.IsNotFound(delErr) {
-				logger.Error(delErr, "failed to delete uninstallation secret", "secret", secret.Name)
-				return ctrl.Result{}, delErr
+				return ctrl.Result{}, fmt.Errorf("failed to delete uninstallation secret %s: %w", secret.Name, delErr)
 			}
 			logger.Info("deleted uninstallation secret", "secret", secret.Name)
 		}
@@ -72,8 +72,7 @@ func (r *ByoHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 		}
 		byoHost.Spec.UninstallationSecret = nil
 		if patchErr = helper.Patch(ctx, byoHost); patchErr != nil {
-			logger.Error(patchErr, "failed to clear uninstallationSecret reference on ByoHost")
-			return ctrl.Result{}, patchErr
+			return ctrl.Result{}, fmt.Errorf("failed to clear uninstallationSecret reference on ByoHost: %w", patchErr)
 		}
 		logger.Info("cleared uninstallationSecret reference on ByoHost")
 	}

--- a/controllers/infrastructure/byohost_controller.go
+++ b/controllers/infrastructure/byohost_controller.go
@@ -10,6 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/patch"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -62,6 +63,19 @@ func (r *ByoHostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ 
 			}
 			logger.Info("deleted uninstallation secret", "secret", secret.Name)
 		}
+
+		// Clear the stale reference so re-used hosts get a fresh uninstall secret
+		// on their next machine assignment.
+		helper, patchErr := patch.NewHelper(byoHost, r.Client)
+		if patchErr != nil {
+			return ctrl.Result{}, patchErr
+		}
+		byoHost.Spec.UninstallationSecret = nil
+		if patchErr = helper.Patch(ctx, byoHost); patchErr != nil {
+			logger.Error(patchErr, "failed to clear uninstallationSecret reference on ByoHost")
+			return ctrl.Result{}, patchErr
+		}
+		logger.Info("cleared uninstallationSecret reference on ByoHost")
 	}
 
 	return ctrl.Result{}, nil

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -302,12 +302,23 @@ func setControlPlaneIP(ctx context.Context, dockerClient *client.Client) {
 		return
 	}
 	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
-	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
+
+	// kind networks may include IPv6 IPAM configs; find the first IPv4 subnet.
+	var ipv4Subnet string
+	for _, cfg := range inspect.IPAM.Config {
+		if strings.Contains(cfg.Subnet, ".") {
+			ipv4Subnet = cfg.Subnet
+			break
+		}
+	}
+	Expect(ipv4Subnet).NotTo(BeEmpty(), "no IPv4 subnet found in kind network IPAM config")
+	ipOctets := strings.Split(ipv4Subnet, ".")
 
 	// The ControlPlaneEndpoint is a static IP that is in the hosts'
 	// subnet but outside of its DHCP range. We believe 151 is a pretty
 	// high number and we have < 10 containers being spun up, so we
 	// can safely use this IP for the ControlPlaneEndpoint
+	Expect(len(ipOctets)).To(BeNumerically(">=", 4), "unexpected subnet format: %s", ipv4Subnet)
 	ipOctets[3] = "151"
 	ip := strings.Join(ipOctets, ".")
 	err := os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)


### PR DESCRIPTION
## Problem

After the manager deletes the uninstall secret, the spec.uninstallationSecret reference on the ByoHost object was left non-nil. This caused re-used hosts to be skipped by setUninstallationSecretForByoHost (which only sets the ref when nil), leaving them pointing at a stale/deleted secret.

## Fix
Now the manager patches spec.uninstallationSecret = nil immediately after deletion, ensuring a re-used host picks up the correct new secret on its next machine assignment.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->