### PR TITLE
ci: bump golang docker image to 1.24.5 in host-agent-binary target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ host-agent-binary: $(RELEASE_DIR)
 		-e GOARCH=$(GOARCH) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
-		golang:1.20.7 \
+		golang:1.24.5 \
 		go build -buildvcs=false -a -ldflags "$(GOLDFLAGS)" \
 		-o ./bin/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(HOST_AGENT_DIR)
 


### PR DESCRIPTION
Go 1.20 predates the toolchain directive (introduced in 1.21), so
the build failed with "unknown directive: toolchain". Bumped to
1.24.5 to match the Go version used in CI workflows and satisfy the
toolchain requirement without triggering an auto-download.
