### PR TITLE
KAAP-528: Support Ubuntu 24.04 and k8s 1.33+

### DIFF
--- a/.ci/build-push-bundle.sh
+++ b/.ci/build-push-bundle.sh
@@ -41,19 +41,16 @@ case "$UBUNTU_VERSION" in
     "22.04")
         BUNDLE_NAME="byoh-bundle-ubuntu_22.04_x86-64_k8s"
         ;;
+    "24.04")
+        BUNDLE_NAME="byoh-bundle-ubuntu_24.04_x86-64_k8s"
+        ;;
     *)
         echo "Error: Unsupported Ubuntu version '$UBUNTU_VERSION'"
-        echo "Supported versions are: 20.04, 22.04"
+        echo "Supported versions are: 20.04, 22.04, 24.04"
         docker rm byoh-bundle-container
         exit 1
         ;;
 esac
-
-if [ "$UBUNTU_VERSION" = "20.04" ]; then
-    BUNDLE_NAME="byoh-bundle-ubuntu_20.04.1_x86-64_k8s"
-else
-    BUNDLE_NAME="byoh-bundle-ubuntu_22.04_x86-64_k8s"
-fi
 
 # Push bundle
 echo "pushing oci bundle to quay.io/platform9/$BUNDLE_NAME"

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -73,7 +73,9 @@ func NewInstaller(ctx context.Context, osDist, arch, k8sVersion string, download
 	var installer K8sInstaller
 	var err error
 
-	if strings.Contains(osbundle, "Ubuntu_22.04") {
+	if strings.Contains(osbundle, "Ubuntu_24.04") {
+		installer, err = algo.NewUbuntu24_04Installer(ctx, arch, addrs)
+	} else if strings.Contains(osbundle, "Ubuntu_22.04") {
 		installer, err = algo.NewUbuntu22_04Installer(ctx, arch, addrs)
 	} else {
 		installer, err = algo.NewUbuntu20_04Installer(ctx, arch, addrs)

--- a/installer/internal/algo/ubuntu24_04k8s.go
+++ b/installer/internal/algo/ubuntu24_04k8s.go
@@ -1,0 +1,39 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package algo
+
+import (
+	"context"
+)
+
+const (
+	// systemdCgroupConfig is the command to enable systemd cgroup in containerd for Ubuntu 24.04
+	systemdCgroupConfig2404 = "sed -i s/SystemdCgroup\\ =\\ false/SystemdCgroup\\ =\\ true/ /etc/containerd/config.toml"
+)
+
+// Ubuntu24_04Installer represent the installer implementation for ubuntu24.04.* os distribution
+type Ubuntu24_04Installer struct {
+	*BaseUbuntuInstaller
+}
+
+// NewUbuntu24_04Installer will return new Ubuntu24_04Installer instance
+func NewUbuntu24_04Installer(ctx context.Context, arch, bundleAddrs string) (*Ubuntu24_04Installer, error) {
+	base, err := NewBaseUbuntuInstaller(ctx, arch, bundleAddrs, systemdCgroupConfig2404)
+	if err != nil {
+		return nil, err
+	}
+	return &Ubuntu24_04Installer{
+		BaseUbuntuInstaller: base,
+	}, nil
+}
+
+// Install will return k8s install script
+func (s *Ubuntu24_04Installer) Install() string {
+	return s.BaseUbuntuInstaller.Install()
+}
+
+// Uninstall will return k8s uninstall script
+func (s *Ubuntu24_04Installer) Uninstall() string {
+	return s.BaseUbuntuInstaller.Uninstall()
+}

--- a/installer/registry.go
+++ b/installer/registry.go
@@ -116,20 +116,23 @@ func GetSupportedRegistry() registry {
 		// BYOH Bundle Repository. Associate bundle with installer
 		linuxDistro20_04 := "Ubuntu_20.04.1_x86-64"
 		linuxDistro22_04 := "Ubuntu_22.04_x86-64"
+		linuxDistro24_04 := "Ubuntu_24.04_x86-64"
 
 		reg.AddBundleInstaller(linuxDistro20_04, "v1.31.*")
 
 		reg.AddBundleInstaller(linuxDistro22_04, "v1.31.*")
+		reg.AddBundleInstaller(linuxDistro24_04, "v1.3*")
 		/*
 		 * PLACEHOLDER - ADD MORE K8S VERSIONS HERE
 		 */
 
 		// Match any patch version of the specified Major & Minor K8s version
-		reg.AddK8sFilter("v1.31.*")
+		reg.AddK8sFilter("v1.3*")
 
 		// Match concrete os version to repository os version
 		reg.AddOsFilter("Ubuntu_20.04.*_x86-64", linuxDistro20_04)
 		reg.AddOsFilter("Ubuntu_22.04.*_x86-64", linuxDistro22_04)
+		reg.AddOsFilter("Ubuntu_24.04.*_x86-64", linuxDistro24_04)
 		/*
 		 * PLACEHOLDER - POINT MORE DISTRO VERSIONS
 		 */

--- a/installer/registry_internal_test.go
+++ b/installer/registry_internal_test.go
@@ -1,4 +1,3 @@
-// Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package installer
@@ -109,14 +108,18 @@ var _ = Describe("Byohost Installer Tests", func() {
 
 		It("Should match with the supported os and k8s versions", func() {
 			osFilters, osBundles := r.ListOS()
-			Expect(osFilters).To(ContainElements("Ubuntu_20.04.*_x86-64"))
-			Expect(osFilters).To(HaveLen(1))
-			Expect(osBundles).To(ContainElements("Ubuntu_20.04.1_x86-64"))
-			Expect(osBundles).To(HaveLen(1))
+			Expect(osFilters).To(ContainElements("Ubuntu_20.04.*_x86-64", "Ubuntu_22.04.*_x86-64", "Ubuntu_24.04.*_x86-64"))
+			Expect(osFilters).To(HaveLen(3))
+			Expect(osBundles).To(ContainElements("Ubuntu_20.04.1_x86-64", "Ubuntu_22.04_x86-64", "Ubuntu_24.04_x86-64"))
+			Expect(osBundles).To(HaveLen(3))
 
 			osBundleResult := r.ListK8s("Ubuntu_20.04.1_x86-64")
-			Expect(osBundleResult).To(ContainElements("v1.24.*", "v1.25.*", "v1.26.*"))
-			Expect(osBundleResult).To(HaveLen(3))
+			Expect(osBundleResult).To(ContainElements("v1.31.*"))
+			Expect(osBundleResult).To(HaveLen(1))
+
+			osBundleResult = r.ListK8s("Ubuntu_24.04_x86-64")
+			Expect(osBundleResult).To(ContainElements("v1.3*"))
+			Expect(osBundleResult).To(HaveLen(1))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Add `Ubuntu24_04Installer` backed by `BaseUbuntuInstaller` with same systemd cgroup sed command as Ubuntu 22.04
- Register Ubuntu 24.04 in bundle registry with `v1.3*` k8s pattern (covers 1.31–1.33+)
- Add `"24.04"` case to `.ci/build-push-bundle.sh`; remove redundant if/else that overwrote case result for 20.04/22.04

Jira: [KAAP-528](https://platform9.atlassian.net/browse/KAAP-528)

[KAAP-528]: https://platform9.atlassian.net/browse/KAAP-528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ