### PR TITLE
fix: remove cluster-name-cp label when releasing a CP ByoHost

### DIFF
--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -22,6 +22,8 @@ const (
 	BundleLookupBaseRegistryAnnotation = "byoh.infrastructure.cluster.x-k8s.io/bundle-registry"
 	// ClusterLabel label is used to mark a cluster where it is attached to
 	ClusterLabel = "kaapi.pf9.io/cluster-name"
+	// ClusterLabelCP label is used to mark a control-plane host attached to a cluster
+	ClusterLabelCP = "kaapi.pf9.io/cluster-name-cp"
 	// Max k8s label value length
 	MaxK8sLabelValueLength = 63
 	LabelHashLength        = 8 // Using 8 chars of SHA256 hex

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -661,6 +661,7 @@ func (r *ByoMachineReconciler) markHostForCleanup(ctx context.Context, machineSc
 	} else {
 		logger.Info("Removing pf9 cluster label %s from ByoHost %s", infrav1.ClusterLabel, machineScope.ByoHost.Name)
 		delete(machineScope.ByoHost.Labels, infrav1.ClusterLabel)
+		delete(machineScope.ByoHost.Labels, infrav1.ClusterLabelCP)
 	}
 
 	// Issue the patch for byohost


### PR DESCRIPTION
## Problem
We have introduced new label `kaapi.pf9.io/cluster-name-cp` for control-plane nodes for ccp support in byoh. When a CCP cluster is deleted, markHostForCleanup only removed the worker label (kaapi.pf9.io/cluster-name) but not the CP variant (kaapi.pf9.io/cluster-name-cp). This lefts stale CP labels on hosts after deletion, blocking re-use of the same hosts with a new cluster of the same name.

## Fix

- Add ClusterLabelCP constant and delete it alongside ClusterLabel in the label-removal path.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->